### PR TITLE
Tweak migration

### DIFF
--- a/credstash-migrate-autoversion.py
+++ b/credstash-migrate-autoversion.py
@@ -3,6 +3,14 @@ import credstash
 import copy
 
 
+def isInt(s):
+    try:
+        int(s)
+        return True
+    except ValueError:
+        return False
+
+
 def updateVersions(region="us-east-1", table="credential-store"):
     '''
     do a full-table scan of the credential-store,
@@ -17,14 +25,13 @@ def updateVersions(region="us-east-1", table="credential-store"):
     items = response["Items"]
 
     for old_item in items:
-        try:
-            int(old_item['version'])
+        if isInt(old_item['version']):
             new_item = copy.copy(old_item)
             new_item['version'] = credstash.paddedInt(new_item['version'])
             if new_item['version'] != old_item['version']:
                 secrets.put_item(Item=new_item)
                 secrets.delete_item(Key={'name': old_item['name'], 'version': old_item['version']})
-        except:
+        else:
             print "Skipping item: %s, %s" % (old_item['name'], old_item['version'])
 
 

--- a/credstash-migrate-autoversion.py
+++ b/credstash-migrate-autoversion.py
@@ -1,0 +1,32 @@
+import boto3
+import credstash
+import copy
+
+
+def updateVersions(region="us-east-1", table="credential-store"):
+    '''
+    do a full-table scan of the credential-store,
+    and update the version format of every credential if it is an integer
+    '''
+    dynamodb = boto3.resource('dynamodb', region_name=region)
+    secrets = dynamodb.Table(table)
+
+    response = secrets.scan(ProjectionExpression="#N, version, #K, contents, hmac",
+                            ExpressionAttributeNames={"#N": "name", "#K": "key"})
+
+    items = response["Items"]
+
+    for old_item in items:
+        try:
+            int(old_item['version'])
+            new_item = copy.copy(old_item)
+            new_item['version'] = credstash.paddedInt(new_item['version'])
+            if new_item['version'] != old_item['version']:
+                secrets.put_item(Item=new_item)
+                secrets.delete_item(Key={'name': old_item['name'], 'version': old_item['version']})
+        except:
+            print "Skipping item: %s, %s" % (old_item['name'], old_item['version'])
+
+
+if __name__ == "__main__":
+    updateVersions()

--- a/credstash.py
+++ b/credstash.py
@@ -44,6 +44,7 @@ from Crypto.Hash.HMAC import HMAC
 from Crypto.Util import Counter
 
 DEFAULT_REGION = "us-east-1"
+PAD_LEN = 19 # number of digits in sys.maxint
 WILDCARD_CHAR = "*"
 
 
@@ -124,6 +125,14 @@ def csv_dump(dictionary):
     return csvfile.getvalue()
 
 
+def paddedInt(i):
+    '''
+    return a string that contains `i`, left-padded with 0's up to PAD_LEN digits
+    '''
+    i_str = str(i)
+    pad = PAD_LEN - len(i_str)
+    return (pad * "0") + i_str
+
 def getHighestVersion(name, region="us-east-1", table="credential-store"):
     '''
     Return the highest version of `name` in the table
@@ -187,7 +196,7 @@ def putSecret(name, secret, version, kms_key="alias/credstash",
 
     data = {}
     data['name'] = name
-    data['version'] = version if version != "" else "1"
+    data['version'] = version if version != "" else paddedInt(1)
     data['key'] = b64encode(wrapped_key).decode('utf-8')
     data['contents'] = b64encode(c_text).decode('utf-8')
     data['hmac'] = b64hmac
@@ -470,7 +479,7 @@ def main():
                 latestVersion = getHighestVersion(args.credential, region,
                                                   args.table)
                 try:
-                    version = str(int(latestVersion) + 1)
+                    version = paddedInt(int(latestVersion) + 1)
                 except ValueError:
                     printStdErr("Can not autoincrement version. The current "
                                 "version: %s is not an int" % latestVersion)


### PR DESCRIPTION
Made a tweak and did a PR this time so we could discuss / tweak further. Here's the output at present:

```
scramble:credstash dom-at-luminal$ ./credstash put foo bar
foo has been stored
scramble:credstash dom-at-luminal$ ./credstash put foo baz
foo version 1 is already in the credential store. Use the -v flag to specify a new version
scramble:credstash dom-at-luminal$ ./credstash put foo baz -a
foo has been stored
scramble:credstash dom-at-luminal$ ./credstash put vers bar -v 1.1.9
vers has been stored
scramble:credstash dom-at-luminal$ ./credstash put vers baz -v 1.2.0
vers has been stored
scramble:credstash dom-at-luminal$ ./credstash put dttm bar -v 20151105
dttm has been stored
scramble:credstash dom-at-luminal$ ./credstash put dttm baz -v 20151106
dttm has been stored
scramble:credstash dom-at-luminal$ ./credstash put dttmb bar -v 2015-11-06
dttmb has been stored
scramble:credstash dom-at-luminal$ git checkout tweak-migration
Switched to branch 'tweak-migration'
Your branch is up-to-date with 'origin/tweak-migration'.
scramble:credstash dom-at-luminal$ ./credstash list
dttm  -- version 20151105
dttm  -- version 20151106
dttmb -- version 2015-11-06
foo   -- version 1
foo   -- version 2
vers  -- version 1.1.9
vers  -- version 1.2.0
scramble:credstash dom-at-luminal$ python ./credstash-migrate-autoversion.py
Skipping item: dttmb, 2015-11-06
Skipping item: vers, 1.1.9
Skipping item: vers, 1.2.0
scramble:credstash dom-at-luminal$ ./credstash list
dttm  -- version 0000000000020151105
dttm  -- version 0000000000020151106
dttmb -- version 2015-11-06
foo   -- version 0000000000000000001
foo   -- version 0000000000000000002
vers  -- version 1.1.9
vers  -- version 1.2.0
```

I think we have to advise people not to use if they used the -v flag for custom versioning.