### PR TITLE
Fix the test for whether a region is valid.

### DIFF
--- a/credstash.py
+++ b/credstash.py
@@ -473,7 +473,7 @@ def main():
 
     try:
         region = args.region
-        boto3.resource('dynamodb')
+        boto3.resource('dynamodb', region_name=region)
     except botocore.exceptions.NoRegionError:
         region = DEFAULT_REGION
 


### PR DESCRIPTION
We weren't actually checking whether the region passed on the
command-line was valid, but rather whether there was a default region
available via either .aws/config or the environment. If there was no
such region, we would unconditionally fall back on DEFAULT_REGION,
instead of trying the one passed on the command line.