### PR TITLE
Adding IAM Assumerole Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ optional arguments:
   -t TABLE, --table TABLE
                         DynamoDB table to use for credential storage
 ```
-
+  -n ARN, --arn ARN     AWS IAM ARN for AssumeRole
 ## IAM Policies
 
 ### Secret Writer

--- a/credstash.py
+++ b/credstash.py
@@ -495,11 +495,11 @@ def main():
                                  "credential (update the credential; "
                                  "defaults to version `1`).")
     parsers[action].add_argument("-a", "--autoversion", action="store_true",
-                                help="Automatically increment the version of "
-                                "the credential to be stored. This option "
-                                "causes the `-v` flag to be ignored. "
-                                "(This option will fail if the currently stored "
-                                "version is not numeric.)")
+                                 help="Automatically increment the version of "
+                                 "the credential to be stored. This option "
+                                 "causes the `-v` flag to be ignored. "
+                                 "(This option will fail if the currently stored "
+                                 "version is not numeric.)")
     parsers[action].set_defaults(action=action)
 
     action = 'setup'


### PR DESCRIPTION
I've added support for assuming an IAM role in another account. This normally can be done via the `aws` config file however not in the case of an EC2 instance with an IAM instance profile. Just for clarification Ill go over my configuration:

# Example
### Account-0000001:
* EC2 instance: Attached with instance profile:
```
{
    "Statement": [
        {
            "Resource": [
                "arn:aws:iam::0000002:role/credstash"
            ],
            "Action": [
                "sts:AssumeRole"
            ],
            "Effect": "Allow"
        }
    ]
}
```

### Account-0000002:
* IAM role: Trust Relationship to `account-0000001` and permissions:
```
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Sid": "",
      "Effect": "Allow",
      "Principal": {
        "AWS": "arn:aws:iam::0000001:root"
      },
      "Action": "sts:AssumeRole"
    }
  ]
}
```
```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Action": [
                "kms:Decrypt",
                "kms:CreateGrant"
            ],
            "Effect": "Allow",
            "Resource": "arn:aws:kms:us-east-1:0000002:key/xxxxxxxxxx"
        },
        {
            "Action": [
                "dynamodb:GetItem",
                "dynamodb:Query",
                "dynamodb:Scan"
            ],
            "Effect": "Allow",
            "Resource": "arn:aws:dynamodb:us-east-1:0000002:table/credential-store"
        }
    ]
}
```
* Dynamodb
* KMS key

Now from the EC2 instance in `account0000001` I can run an `credstash --arn` to get an the resources in `account000002`:
```bash
~$ credstash --arn 'arn:aws:iam::0000002:role/credstash' get 'somescret'
supersecrettext
```

## Additionally
I also made sure that `--profile` and `--arn` are mutually exclusive:
```bash
~$ credstash -arn 'arn:aws:iam::0000002:role/credstash' --profile profile1 get 'somesecret'
usage: credstash [-h] [-r REGION] [-t TABLE] [-p PROFILE | -n ARN]
                 {delete,get,getall,list,put,setup} ...
credstash: error: invalid choice: 'arn:aws:iam::0000002:role/credstash' (choose from 'delete', 'get', 'getall', 'list', 'put', 'setup')
```

# Lastly
There seems to be a speed increase during some operations because of the shared session. All tests done from ec2 instance in AWS.

Existing code with roughly `100 items`:
```
~$ time credstash --profile "dynamodb" getall
{
     <records1>...
}
real    0m17.518s
user    0m11.009s
sys     0m1.000s
```


This PR same amount of items:
```
~$ time credstash -n "arn:aws:iam::0000002:role/credstash" getall
{
    <records1>....
}
real    0m5.815s
user    0m3.048s
sys     0m0.272s
```

I have tested the code manually using `--arn` with instance profiles in ec2 and the `--profile` flags. I hope this is something that fits well in the scope of the project. Please let me know if you have any questions!

Keep up the great work!

~Rob