### PR TITLE
Create a decorator so failed commands cleanly exit

### DIFF
--- a/credstash.py
+++ b/credstash.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import print_function
 
 import argparse
 import csv
@@ -42,6 +43,7 @@ from Crypto.Cipher import AES
 from Crypto.Hash import SHA256
 from Crypto.Hash.HMAC import HMAC
 from Crypto.Util import Counter
+
 
 DEFAULT_REGION = "us-east-1"
 PAD_LEN = 19 # number of digits in sys.maxint
@@ -164,6 +166,12 @@ def getHighestVersion(name, region=None, table="credential-store",
     return response["Items"][0]["version"]
 
 def clean_fail(func):
+    '''
+    A decorator to cleanly exit on a failed call to AWS.
+    catch a `botocore.exceptions.ClientError` raised from an action.
+    This sort of error is raised if you are targeting a region that
+    isn't set up (see, `credstash setup`.
+    '''
     def func_wrapper(*args, **kwargs):
         try:
             func(*args, **kwargs)

--- a/credstash.py
+++ b/credstash.py
@@ -174,14 +174,13 @@ def clean_fail(func):
     '''
     def func_wrapper(*args, **kwargs):
         try:
-            func(*args, **kwargs)
+            return func(*args, **kwargs)
         except botocore.exceptions.ClientError as e:
             print(str(e), file=sys.stderr)
             sys.exit(1)
     return func_wrapper
 
 
-@clean_fail
 def listSecrets(region=None, table="credential-store", **kwargs):
     '''
     do a full-table scan of the credential-store,
@@ -239,7 +238,6 @@ def putSecret(name, secret, version, kms_key="alias/credstash",
     return secrets.put_item(Item=data, ConditionExpression=Attr('name').not_exists())
 
 
-@clean_fail
 def getAllSecrets(version="", region=None, table="credential-store",
                   context=None, **kwargs):
     '''
@@ -492,6 +490,7 @@ def get_assumerole_credentials(arn):
                 aws_session_token=credentials['SessionToken'])
 
 
+@clean_fail
 def list_credentials(region, args, **session_params):
     credential_list = listSecrets(region=region,
                                   table=args.table,


### PR DESCRIPTION
 - only applied it to the list though
 - pulled th parsers generation into a helper function


I'd like to pull out each of the other actions into functions and do the same, and split up the parser function some more.

More of a RFC than a please merge this now;