### PR TITLE
Allow default version for putSecret

### DIFF
--- a/credstash.py
+++ b/credstash.py
@@ -205,7 +205,7 @@ def listSecrets(region=None, table="credential-store", **kwargs):
     return response["Items"]
 
 
-def putSecret(name, secret, version, kms_key="alias/credstash",
+def putSecret(name, secret, version="", kms_key="alias/credstash",
               region=None, table="credential-store", context=None,
               digest="SHA256", **kwargs):
     '''


### PR DESCRIPTION
The logic for the putSecret function previously required a version, but performed a default check in the function to add a padded 1 if the version is set to an empty string. This commit sets `version` to an empty string by default in order to take advantage of the default value when a library user does not provide a version. This change should not break current integrations with the library.