### PR TITLE
Support dotenv getall export format

### DIFF
--- a/credstash.py
+++ b/credstash.py
@@ -143,6 +143,14 @@ def csv_dump(dictionary):
     return csvfile.getvalue()
 
 
+def dotenv_dump(dictionary):
+    dotenv_buffer = StringIO()
+    for key in dictionary:
+        dotenv_buffer.write(key.upper() + "=" + dictionary[key])
+    dotenv_buffer.seek(0)
+    return dotenv_buffer.read()
+
+
 def paddedInt(i):
     '''
     return a string that contains `i`, left-padded with 0's up to PAD_LEN digits
@@ -287,6 +295,9 @@ def getAllAction(args, region, **session_params):
         output_args = {"default_flow_style": False}
     elif args.format == 'csv':
         output_func = csv_dump
+        output_args = {}
+    elif args.format == 'dotenv':
+        output_func = dotenv_dump
         output_args = {}
     print(output_func(secrets, **output_args))
 
@@ -620,10 +631,10 @@ def get_parser():
                                  help="Get a specific version of the "
                                  "credential (defaults to the latest version)")
     parsers[action].add_argument("-f", "--format", default="json",
-                                 choices=["json", "csv"] +
+                                 choices=["json", "csv", "dotenv"] +
                                  ([] if NO_YAML else ["yaml"]),
                                  help="Output format. json(default) " +
-                                 ("" if NO_YAML else "yaml ") + "or csv.")
+                                 ("" if NO_YAML else "yaml ") + " csv or dotenv.")
     parsers[action].set_defaults(action=action)
 
     action = 'list'

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='credstash',
-    version='1.11.0',
+    version='1.12.0',
     description='A utility for managing secrets in the cloud using AWS KMS and DynamoDB',
     license='Apache2',
     url='https://github.com/LuminalOSS/credstash',


### PR DESCRIPTION
I was interested in this as well and decided to undertake it. This provides an export dotenv format (key=value) option requested in issue #76 . I'm a bit iffy with regards to the name (dotenv) but couldn't think of anything better - looking forward to your thoughts on that, too. Thanks! 