### PR TITLE
Move --key parameter to super parameters

### DIFF
--- a/credstash.py
+++ b/credstash.py
@@ -575,6 +575,10 @@ def get_parser():
     parsers['super'].add_argument("-t", "--table", default="credential-store",
                                   help="DynamoDB table to use for "
                                   "credential storage")
+    parsers['super'].add_argument("-k", "--key", default="alias/credstash",
+                                  help="the KMS key-id of the master key "
+                                  "to use. See the README for more "
+                                  "information. Defaults to alias/credstash")
     role_parse = parsers['super'].add_mutually_exclusive_group()
     role_parse.add_argument("-p", "--profile", default=None,
                             help="Boto config profile to use when "
@@ -660,10 +664,6 @@ def get_parser():
                                  help="encryption context key/value pairs "
                                  "associated with the credential in the form "
                                  "of \"key=value\"")
-    parsers[action].add_argument("-k", "--key", default="alias/credstash",
-                                 help="the KMS key-id of the master key "
-                                 "to use. See the README for more "
-                                 "information. Defaults to alias/credstash")
     parsers[action].add_argument("-v", "--version", default="",
                                  help="Put a specific version of the "
                                  "credential (update the credential; "


### PR DESCRIPTION
Means it's available to all commands (previously it was possible to specify in `put` but not in `get`).

This is a breaking change in the sense that you used to have to write `credstash put keyname value --key='alias/somekms'` and now you have to write `credstash --key='alias/somekms' put keyname value`.  But since it was impossible to use any of the `get` commands with non-standard KMS, I conclude that no one can be using the deprecated syntax!