### PR TITLE
Get secrets by wildcard when using as a library

### DIFF
--- a/credstash.py
+++ b/credstash.py
@@ -259,13 +259,24 @@ def putSecret(name, secret, version="", kms_key="alias/credstash",
 
 
 def getAllSecrets(version="", region=None, table="credential-store",
-                  context=None, **kwargs):
+                  context=None, credential=None, **kwargs):
     '''
     fetch and decrypt all secrets
     '''
     output = {}
     secrets = listSecrets(region, table, **kwargs)
-    for credential in set([x["name"] for x in secrets]):
+
+    # Only return the secrets that match the pattern in `credential`
+    # This already works out of the box with the CLI get action,
+    # but that action doesn't support wildcards when using as library
+    if credential and WILDCARD_CHAR in credential:
+            names = set(expand_wildcard(credential,
+                                        [x["name"]
+                                        for x in secrets]))
+    else:
+        names = set(x["name"] for x in secrets)
+
+    for credential in names:
         try:
             output[credential] = getSecret(credential,
                                            version,

--- a/credstash.py
+++ b/credstash.py
@@ -270,9 +270,9 @@ def getAllSecrets(version="", region=None, table="credential-store",
     # This already works out of the box with the CLI get action,
     # but that action doesn't support wildcards when using as library
     if credential and WILDCARD_CHAR in credential:
-            names = set(expand_wildcard(credential,
-                                        [x["name"]
-                                        for x in secrets]))
+        names = set(expand_wildcard(credential,
+                                    [x["name"]
+                                    for x in secrets]))
     else:
         names = set(x["name"] for x in secrets)
 


### PR DESCRIPTION
I wasn't able to find a convenient way to get secrets by wildcard programmatically, when using credstash as a library in a Python program. 

It's possible to use the existing `getSecretAction` passing in an `args` object with a `credential` attribute containing a wildcard, but that requires the client to know too much about the internals of `credstash`. It's also possible to use `getAllSecrets` and filter the secrets on the wildcard after the fact, but that requires every library user to implement their own filtering.

So in order to make `credstash` filtering work out of the box when used programmatically, I added an optional `credential` argument to `getAllSecrets`, which is used to filter out secrets whose `name` doesn't match the `credential` wildcard pattern before returning the values.

Example use:

```python
>>> import credstash
>>> credstash.getAllSecrets()
{'roger.mysecret2': 'lol2', 'roger.mysecret': 'lol', 'redispassword': 's3cr3t1222', 'dbpassword': 's3cr3t111', 'dbhost': 'db-host.somedomain.example.com', 'dbport': '12345', 'roger.mysecret3': 'lol3', 'password': 'nottellingyou'}
>>> credstash.getAllSecrets(credential='roger*')
{'roger.mysecret2': 'lol2', 'roger.mysecret': 'lol', 'roger.mysecret3': 'lol3'}
```
