### PR TITLE
Add creds3 CLI for credstash to enable S3 credential storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,103 @@
+**Table of Contents**  *generated with [DocToc](http://doctoc.herokuapp.com/)*
+
+- [CredStash](#credstash)
+	- [Quick Installation](#quick-installation)
+		- [Linux install-time dependencies](#linux-install-time-dependencies)
+	- [What is this?](#what-is-this)
+	- [Compatibility with Other Languages](#compatibility-with-other-languages)
+	- [How does it work?](#how-does-it-work)
+		- [`credstash setup`](#credstash-setup)
+		- [`creds3 setup`](#creds3-setup)
+		- [Stashing Secrets](#stashing-secrets)
+		- [Getting Secrets](#getting-secrets)
+		- [Controlling and Auditing Secrets](#controlling-and-auditing-secrets)
+		- [Versioning Secrets](#versioning-secrets)
+			- [Special Note for Those Using Credstash Auto-Versioning Before December 2015](#special-note-for-those-using-credstash-auto-versioning-before-december-2015)
+	- [Dependencies](#dependencies)
+	- [Setup](#setup)
+		- [tl;dr](#tldr)
+		- [Setting up KMS](#setting-up-kms)
+		- [Setting up credstash](#setting-up-credstash)
+		- [Working with multiple AWS accounts (profiles)](#working-with-multiple-aws-accounts-profiles)
+	- [Usage](#usage)
+	- [IAM Policies](#iam-policies)
+		- [Secret Writer](#secret-writer)
+		- [Secret Reader](#secret-reader)
+		- [Setup Permissions](#setup-permissions)
+	- [Security Notes](#security-notes)
+	- [Frequently Asked Questions (FAQ)](#frequently-asked-questions-faq)
+		- [1. Where is the master key stored?](#1-where-is-the-master-key-stored)
+		- [2. How is credential rotation handled?](#2-how-is-credential-rotation-handled)
+		- [3. How much do the AWS services needed to run credstash cost?](#3-how-much-do-the-aws-services-needed-to-run-credstash-cost)
+			- [DynamoDB credential storage](#dynamodb-credential-storage)
+			- [S3 credential storage](#s3-credential-storage)
+		- [4. What should I use for credential store: S3 or DynamoDB?](#4-what-should-i-use-for-credential-store-s3-or-dynamodb)
+		- [5. Where can I learn more about use cases and context for something like credstash?](#5-where-can-i-learn-more-about-use-cases-and-context-for-something-like-credstash)
+
 # CredStash
 
+Credstash is a simple command-line utility for managing KMS key-encrypted
+credentials in DynamoDB or S3 credential stores.
+It has two distinct command line interfaces for doing that:
+
+- `credstash`: KMS + DynamoDB
+- `creds3`: KMS + S3
+
 ## Quick Installation
+
 0. (Linux only) Install dependencies 
 1. `pip install credstash`
 2. Set up a key called credstash in KMS (found in the IAM console)
 3. Make sure you have AWS creds in a place that boto/botocore can read them
-4. `credstash setup`
+4. `credstash setup` or `creds3 setup`
 
 ### Linux install-time dependencies
-Credstash recently moved from PyCrypto to `cryptography`. `cryptography` uses pre-built binary wheels on OSX and Windows, but does not on Linux. That means that you need to install some dependencies if you want to run credstash on linux. 
 
-For Debian and Ubuntu, the following command will ensure that the required dependencies are installed:
-```
-$ sudo apt-get install build-essential libssl-dev libffi-dev python-dev
-```
-For Fedora and RHEL-derivatives, the following command will ensure that the required dependencies are installed:
-```
-$ sudo yum install gcc libffi-devel python-devel openssl-devel
-```
+Credstash recently moved from PyCrypto to `cryptography`.
+`cryptography` uses pre-built binary wheels on OSX and Windows, but does not
+on Linux. That means that you need to install some dependencies if you want
+to run credstash on linux. 
 
-In either case, once you've installed the dependencies, you can do `pip install credstash` as usual.
+For Debian and Ubuntu, the following command will ensure that the required
+dependencies are installed:
 
-See https://cryptography.io/en/latest/installation/ for more information.
+    $ sudo apt-get install build-essential libssl-dev libffi-dev python-dev
+
+For Fedora and RHEL-derivatives, the following command will ensure that the
+required dependencies are installed:
+
+
+    $ sudo yum install gcc libffi-devel python-devel openssl-devel
+
+In either case, once you've installed the dependencies, you can do
+`pip install credstash` as usual.
+
+See [this](https://cryptography.io/en/latest/installation/) for more information
 
 
 ## What is this?
-Software systems often need access to some shared credential. For example, your web application needs access to a database password, or an API key for some third party service.
 
-Some organizations build complete credential-management systems, but for most of us, managing these credentials is usually an afterthought. In the best case, people use systems like ansible-vault, which does a pretty good job, but leads to other management issues (like where/how to store the master key). A lot of credential management schemes amount to just SCP'ing a `secrets` file out to the fleet, or in the worst case, burning secrets into the SCM (do a github search on `password`).
+Software systems often need access to some shared credential. For example,
+your web application needs access to a database password, or an API key
+for some third party service.
 
-CredStash is a very simple, easy to use credential management and distribution system that uses AWS Key Management Service (KMS) for key wrapping and master-key storage, and DynamoDB for credential storage and sharing.
+Some organizations build complete credential-management systems, but for most
+of us, managing these credentials is usually an afterthought. In the best case,
+people use systems like ansible-vault, which does a pretty good job, but leads
+to other management issues (like where/how to store the master key).
+A lot of credential management schemes amount to just SCP'ing a `secrets` file
+out to the fleet, or in the worst case, burning secrets into the SCM (do a
+github search on `password`).
+
+CredStash is a very simple, easy to use credential management and distribution
+system that uses AWS Key Management Service (KMS) for key wrapping and
+master-key storage, DynamoDB or S3 for credential storage and sharing.
 
 ## Compatibility with Other Languages 
-A number of great projects exist to provide credstash compatability with other languages. Here are the ones that we know about (feel free to open a pull request if you know of another):
+
+A number of great projects exist to provide credstash compatability with
+other languages. Here are the ones that we know about (feel free to open a
+pull request if you know of another):
 
 - https://github.com/jessecoyle/jcredstash (Java)
 - https://github.com/adorechic/rcredstash (Ruby)
@@ -42,44 +107,162 @@ A number of great projects exist to provide credstash compatability with other l
 - https://github.com/winebarrel/gcredstash (Go)
 - https://github.com/Narochno/Narochno.Credstash (C#)
 
-
 ## How does it work?
-After you complete the steps in the `Setup` section, you will have an encryption key in KMS (in this README, we will refer to that key as the `master key`), and a credential storage table in DDB.
+
+After you complete the steps in the `Setup` section, depending on the command
+you have used: `credstash setup` or `creds3 setup`, you will have an
+encryption key in KMS (in this README, we will refer to that key as the
+`master key`), and a credential storage in a DynamoDB table or S3 bucket
+location.
+
+### `credstash setup`
+
+If you do not specify an DynamoDB table name via the `-t` option to `setup`
+command, the table that will be created by default will have the name of
+`credential-store`.
+
+### `creds3 setup`
+
+If you do not specify an S3 bucket location via the `-l` option to `setup`
+command, the bucket that will be created by default will have the name of
+`credential-store-AWSACCOUNTID` where the `AWSACCOUNTID` is the AWS
+account ID under which the bucket is created.
+
 
 ### Stashing Secrets
-Whenever you want to store/share a credential, such as a database password, you simply run `credstash put [credential-name] [credential-value]`. For example, `credstash put myapp.db.prod supersecretpassword1234`. credstash will go to the KMS and generate a unique data encryption key, which itself is encrypted by the master key (this is called key wrapping). credstash will use the data encryption key to encrypt the credential value. It will then store the encrypted credential, along with the wrapped (encrypted) data encryption key in the credential store in DynamoDB.
 
+Whenever you want to store/share a credential, such as a database password,
+you simply run `credstash put [credential-name] [credential-value]`. For 
+example:
+
+    credstash put myapp.db.prod supersecretpassword1234
+    # OR
+    creds3 put myapp.db.prod supersecretpassword1234
+
+credstash will go to the KMS and generate a unique data encryption key, which
+itself is encrypted by the master key (this is called key wrapping).
+credstash will use the data encryption key to encrypt the credential value.
+It will then store the encrypted credential, along with the wrapped (encrypted)
+data encryption key in the credential store.
+
+In case of `creds3`, the key and its value is stored in the specified S3 bucket
+location under the following structure:
+
+    credential-store-AWSACCOUNTID
+                            |
+                            ├── [credential 1 name]
+                            ...                  ├── [version number 1]
+                                                 ├── [version number 2]
+                                                 ...
 ### Getting Secrets
-When you want to fetch the credential, for example as part of the bootstrap process on your web-server, you simply do `credstash get [credential-name]`. For example, `export DB_PASSWORD=$(credstash get myapp.db.prod)`. When you run `get`, credstash will go and fetch the encrypted credential and the wrapped encryption key from the credential store (DynamoDB). It will then send the wrapped encryption key to KMS, where it is decrypted with the master key. credstash then uses the decrypted data encryption key to decrypt the credential. The credential is printed to `stdout`, so you can use it in scripts or assign it to environment variables.
+
+When you want to fetch the credential, for example as part of the bootstrap
+process on your web-server, you simply do:
+
+    credstash get [credential-name]
+    # OR
+    creds3 get [credential-name]
+
+For example, `export DB_PASSWORD=$(credstash get myapp.db.prod)`. When you run
+`get`, credstash will go and fetch the encrypted credential and the wrapped
+encryption key from the credential store (DynamoDB or S3).
+It will then send the wrapped encryption key to KMS, where it is decrypted with
+the master key. 
+credstash then uses the decrypted data encryption key to decrypt the credential.
+The credential is printed to `stdout`, so you can use it in scripts or assign
+it to environment variables.
 
 ### Controlling and Auditing Secrets
-Optionally, you can include any number of [Encryption Context](http://docs.aws.amazon.com/kms/latest/developerguide/encrypt-context.html) key value pairs to associate with the credential. The exact set of encryption context key value pairs that were associated with the credential when it was `put` in DynamoDB must be provided in the `get` request to successfully decrypt the credential. These encryption context key value pairs are useful to provide auditing context to the encryption and decryption operations in your CloudTrail logs. They are also useful for constraining access to a given credstash stored credential by using KMS Key Policy conditions and KMS Grant conditions. Doing so allows you to, for example, make sure that your database servers and web-servers can read the web-server DB user password but your database servers can not read your web-servers TLS/SSL certificate's private key. A `put` request with encryption context would look like `credstash put myapp.db.prod supersecretpassword1234 app.tier=db environment=prod`. In order for your web-servers to read that same credential they would execute a `get` call like `export DB_PASSWORD=$(credstash get myapp.db.prod environment=prod app.tier=db)`
+
+Optionally, you can include any number of
+[Encryption Context](http://docs.aws.amazon.com/kms/latest/developerguide/encrypt-context.html)
+key value pairs to associate with the credential. The exact set of encryption
+context key value pairs that were associated with the credential when it was
+`put` in credential store must be provided in the `get` request to successfully
+decrypt the credential.
+These encryption context key value pairs are useful to provide
+auditing context to the encryption and decryption operations in your CloudTrail
+logs. They are also useful for constraining access to a given credstash stored
+credential by using KMS Key Policy conditions and KMS Grant conditions.
+Doing so allows you to, for example, make sure that your database servers and
+web-servers can read the web-server DB user password but your database servers
+can not read your web-servers TLS/SSL certificate's private key.
+A `put` request with encryption context would look like
+
+    credstash put myapp.db.prod supersecretpassword1234 app.tier=db \
+        environment=prod
+    # OR
+    creds3 put myapp.db.prod supersecretpassword1234 app.tier=db \
+        environment=prod
+
+In order for your web-servers to read that same credential they would execute
+a `get` call like
+
+    export DB_PASSWORD=$(credstash get myapp.db.prod environment=prod app.tier=db)
+    # OR
+    export DB_PASSWORD=$(creds3 get myapp.db.prod environment=prod app.tier=db)
 
 ### Versioning Secrets
-Credentials stored in the credential-store are versioned and immutable. That is, if you `put` a credential called `foo` with a version of `1` and a value of `bar`, then foo version 1 will always have a value of bar, and there is no way in `credstash` to change its value (although you could go fiddle with the bits in DDB, but you shouldn't do that). Credential rotation is handed through versions. Suppose you do `credstash put foo bar`, and then decide later to rotate `foo`, you can put version 2 of `foo` by doing `credstash put foo baz -v `. The next time you do `credstash get foo`, it will return `baz`. You can get specific credential versions as well (with the same `-v` flag). You can fetch a list of all credentials in the credential-store and their versions with the `list` command.
 
-If you use incrementing integer version numbers (for example, `[1, 2, 3, ...]`), then you can use the `-a` flag with the `put` command to automatically increment the version number. However, because of the lexicographical sorting in DynamoDB, `credstash` will left-pad the version representation with zeros (for example, `[001, 025, 103, ...]`, except to 19 characters, enough to handle `sys.maxint` on 64-bit systems).
+Credentials stored in the credential-store are versioned and immutable.
+That is, if you `put` a credential called `foo` with a version of `1` and
+a value of `bar`, then foo version 1 will always have a value of bar, and
+there is no way in `credstash` to change its value (although you could go fiddle
+with the bits in the version file in the credential store, but you shouldn't
+do that).
+Credential rotation is handed through versions. Suppose you do
+`credstash put foo bar`, and then decide later to rotate `foo`,
+you can put version 2 of `foo` by doing `credstash put -v 2 foo baz`.
+The next time you do `credstash get foo`, it will return `baz`. You can get
+specific credential versions as well (with the `-v <version>` flag). You can
+fetch a list of all credentials in the credential-store and their versions
+with the `list` command.
+
+If you use incrementing integer version numbers
+(for example, `[1, 2, 3, ...]`), then you can use the `-a` flag with the
+`put` command to automatically increment the version number.
+
+In case of DynamoDB credential store however, because of the lexicographical
+sorting, `credstash` will left-pad the version representation with zeros
+(for example, `[001, 025, 103, ...]`, except to 19 characters, enough to
+handle `sys.maxint` on 64-bit systems).
+
 
 #### Special Note for Those Using Credstash Auto-Versioning Before December 2015
-Prior to December 2015, `credstash` auto-versioned with unpadded integers. This resulted in a sorting error once a key hit ten versions. To ensure support for versions that were not numbers (such as dates, build versions, names, etc.), the lexicographical sorting behavior was retained, but the auto-versioning behavior was changed to left-pad integer representations.
 
-If you've used auto-versioning so far, you should run the `credstash-migrate-autoversion.py` script included in the root of the repository. If you are supplying your own version numbers, you should ensure a lexicographic sort of your versions produces the result you desire.
+Prior to December 2015, `credstash` auto-versioned with unpadded integers.
+This resulted in a sorting error once a key hit ten versions. To ensure
+support for versions that were not numbers (such as dates, build versions,
+names, etc.), the lexicographical sorting behavior was retained, but the
+auto-versioning behavior was changed to left-pad integer representations.
+
+If you've used auto-versioning so far, you should run the 
+`credstash-migrate-autoversion.py` script included in the root of the
+repository. If you are supplying your own version numbers, you should ensure
+a lexicographic sort of your versions produces the result you desire.
 
 ## Dependencies
+
 credstash uses the following AWS services:
+
 * AWS Key Management Service (KMS) - for master key management and key wrapping
 * AWS Identity and Access Management - for access control
-* Amazon DynamoDB - for credential storage
+* Amazon DynamoDB (`credstash`) or S3 (`creds3`) - for credential storage
 
 ## Setup
+
 ### tl;dr
+
 1. Set up a key called `credstash` in KMS
 2. Install credstash's python dependencies (or just use pip)
 3. Make sure you have AWS creds in a place that boto/botocore can read them
-4. Run `credstash setup`
+4. Run `credstash setup` for credential store in DynamoDB or `creds3 setup`
+   for using S3 as credential store
 
 ### Setting up KMS
-`credstash` will not currently set up your KMS master key. To create a KMS master key,
+
+`credstash` will not currently set up your KMS master key. To create a KMS
+master key,
 
 1. Go to the AWS console
 2. Go to the IAM console/tab
@@ -90,23 +273,38 @@ credstash uses the following AWS services:
 7. Done!
 
 ### Setting up credstash
-The easiest thing to do is to just run `pip install credstash`. That will download and install credstash and its dependencies (boto and PyCypto).
 
-The second easiest thing to do is to do `python setup.py install` in the `credstash` directory.
+The easiest thing to do is to just run `pip install credstash`. That will
+download and install credstash and its dependencies (boto and PyCypto).
 
-The python dependencies for credstash are in the `requirements.txt` file. You can install them with `pip install -r requirements.txt`.
+The second easiest thing to do is to do `python setup.py install` in the
+`credstash` directory.
 
-In all cases, you will need a C compiler for building `PyCrypto` (you can install `gcc` by doing `apt-get install gcc` or `yum install gcc`).
+The python dependencies for credstash are in the `requirements.txt` file. You
+can install them with `pip install -r requirements.txt`.
 
-You will need to have AWS credentials accessible to boto/botocore. The easiest thing to do is to run credstash on an EC2 instance with an IAM role. Alternatively, you can put AWS credentials in the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables. Or, you can put them in a file (see http://boto.readthedocs.org/en/latest/boto_config_tut.html).
+In all cases, you will need a C compiler for building `PyCrypto` (you can
+install `gcc` by doing `apt-get install gcc` or `yum install gcc`).
 
-You can specify the region in which `credstash` should operate by using the `-r` flag, or by setting the `AWS_DEFAULT_REGION` environment variable. Note that the command line flag takes precedence over the environment variable. If you set neither, then `credstash` will operate against us-east-1.
+You will need to have AWS credentials accessible to boto/botocore. The
+easiest thing to do is to run credstash on an EC2 instance with an IAM role.
+Alternatively, you can put AWS credentials in the `AWS_ACCESS_KEY_ID` and
+`AWS_SECRET_ACCESS_KEY` environment variables.
+Or, you can put them in a file as described
+[here](http://boto.readthedocs.org/en/latest/boto_config_tut.html).
 
-Once credentials are in place, run `credstash setup`. This will create the DDB table needed for credential storage.
+You can specify the region in which `credstash` should operate by using the `-r`
+flag, or by setting the `AWS_DEFAULT_REGION` environment variable.
+Note that the command line flag takes precedence over the environment variable.
+If you set neither, then `credstash` will operate against us-east-1.
+
+Once credentials are in place, run `credstash setup`. This will create the S3
+bucket needed for credential storage.
 
 ### Working with multiple AWS accounts (profiles)
 
-If you need to work with multiple AWS accounts, an easy thing to do is to set up multiple profiles in your `~/.aws/credentials` file. For example,
+If you need to work with multiple AWS accounts, an easy thing to do is to
+set up multiple profiles in your `~/.aws/credentials` file. For example,
 
 ```
 [dev]
@@ -117,203 +315,372 @@ aws_access_key_id= AKIDEXAMPLEASDFASDF
 aws_secret_access_key= SKIDEXAMPLE2103429812039423
 ```
 
-Then, by setting the `AWS_PROFILE` environment variable to the name of the profile, (dev or prod, in this case), you can point credstash at the appropriate account.
+Then, by setting the `AWS_PROFILE` environment variable to the name of the
+profile, (dev or prod, in this case), you can point credstash at the appropriate
+account.
 
-See https://blogs.aws.amazon.com/security/post/Tx3D6U6WSFGOK2H/A-New-and-Standardized-Way-to-Manage-Credentials-in-the-AWS-SDKs for more information.
+See [this document](https://blogs.aws.amazon.com/security/post/Tx3D6U6WSFGOK2H/A-New-and-Standardized-Way-to-Manage-Credentials-in-the-AWS-SDKs)
+for more information.
 
 ## Usage
-```
-usage: credstash [-h] [-r REGION] [-t TABLE] {delete,get,getall,list,put,setup} ...
 
-A credential/secret storage system
+Running `credstash --help` will produce this kind of helpful screen:
 
-delete
-    usage: credstash delete [-h] [-r REGION] [-t TABLE] credential
+    usage: credstash [-h] [-r REGION] [-t TABLE] {delete,get,getall,list,put,setup} ...
+
+    A credential/secret storage system
+
+    delete
+        usage: credstash delete [-h] [-r REGION] [-t TABLE] credential
+
+        positional arguments:
+        credential  the name of the credential to delete
+
+    get
+        usage: credstash get [-h] [-r REGION] [-t TABLE] [-k KEY] [-n] [-v VERSION]
+                            credential [context [context ...]]
+
+        positional arguments:
+        credential            the name of the credential to get. Using the wildcard
+                                character '*' will search for credentials that match
+                                the pattern
+        context               encryption context key/value pairs associated with the
+                                credential in the form of "key=value"
+
+        optional arguments:
+        -n, --noline          Don't append newline to returned value (useful in
+                                scripts or with binary files)
+        -v VERSION, --version VERSION
+                                Get a specific version of the credential (defaults to
+                                the latest version).
+
+    getall
+        usage: credstash getall [-h] [-r REGION] [-t TABLE] [-v VERSION] [-f {json,yaml,csv}]
+                                [context [context ...]]
+
+        positional arguments:
+        context               encryption context key/value pairs associated with the
+                                credential in the form of "key=value"
+
+        optional arguments:
+        -v VERSION, --version VERSION
+                                Get a specific version of the credential (defaults to
+                                the latest version).
+        -f {json,yaml,csv}, --format {json,yaml,csv}
+                                Output format. json(default), yaml or csv.
+
+
+    list
+        usage: credstash list [-h] [-r REGION] [-t TABLE]
+
+    put
+    usage: credstash put [-h] [-k KEY] [-v VERSION] [-a]
+                        credential value [context [context ...]]
 
     positional arguments:
-      credential  the name of the credential to delete
-
-get
-    usage: credstash get [-h] [-r REGION] [-t TABLE] [-k KEY] [-n] [-v VERSION]
-                         credential [context [context ...]]
-
-    positional arguments:
-      credential            the name of the credential to get. Using the wildcard
-                            character '*' will search for credentials that match
-                            the pattern
-      context               encryption context key/value pairs associated with the
+    credential            the name of the credential to store
+    value                 the value of the credential to store or, if beginning
+                            with the "@" character, the filename of the file
+                            containing the value
+    context               encryption context key/value pairs associated with the
                             credential in the form of "key=value"
 
     optional arguments:
-      -n, --noline          Don't append newline to returned value (useful in
-                            scripts or with binary files)
-      -v VERSION, --version VERSION
-                            Get a specific version of the credential (defaults to
-                            the latest version).
+    -h, --help            show this help message and exit
+    -k KEY, --key KEY     the KMS key-id of the master key to use. See the
+                            README for more information. Defaults to
+                            alias/credstash
+    -v VERSION, --version VERSION
+                            Put a specific version of the credential (update the
+                            credential; defaults to version `1`).
+    -a, --autoversion     Automatically increment the version of the credential
+                            to be stored. This option causes the `-v` flag to be
+                            ignored. (This option will fail if the currently
+                            stored version is not numeric.)
 
-getall
-    usage: credstash getall [-h] [-r REGION] [-t TABLE] [-v VERSION] [-f {json,yaml,csv}]
-                            [context [context ...]]
-
-    positional arguments:
-      context               encryption context key/value pairs associated with the
-                            credential in the form of "key=value"
+    setup
+        usage: credstash setup [-h] [-r REGION] [-t TABLE]
 
     optional arguments:
-      -v VERSION, --version VERSION
-                            Get a specific version of the credential (defaults to
-                            the latest version).
-      -f {json,yaml,csv}, --format {json,yaml,csv}
-                            Output format. json(default), yaml or csv.
+    -r REGION, --region REGION
+                            the AWS region in which to operate. If a region is not
+                            specified, credstash will use the value of the
+                            AWS_DEFAULT_REGION env variable, or if that is not
+                            set, us-east-1
+    -l TABLE, --table TABLE
+                            DynamoDB table to use for credential storage
+    -n ARN, --arn ARN     AWS IAM ARN for AssumeRole
 
+A similar help screen is obtained by running the `creds3 --help`, only
+the DynamodDB table options replaced by S3 location.
 
-list
-    usage: credstash list [-h] [-r REGION] [-t TABLE]
-
-put
-usage: credstash put [-h] [-k KEY] [-v VERSION] [-a]
-                     credential value [context [context ...]]
-
-positional arguments:
-  credential            the name of the credential to store
-  value                 the value of the credential to store or, if beginning
-                        with the "@" character, the filename of the file
-                        containing the value
-  context               encryption context key/value pairs associated with the
-                        credential in the form of "key=value"
-
-optional arguments:
-  -h, --help            show this help message and exit
-  -k KEY, --key KEY     the KMS key-id of the master key to use. See the
-                        README for more information. Defaults to
-                        alias/credstash
-  -v VERSION, --version VERSION
-                        Put a specific version of the credential (update the
-                        credential; defaults to version `1`).
-  -a, --autoversion     Automatically increment the version of the credential
-                        to be stored. This option causes the `-v` flag to be
-                        ignored. (This option will fail if the currently
-                        stored version is not numeric.)
-
-setup
-    usage: credstash setup [-h] [-r REGION] [-t TABLE]
-
-optional arguments:
-  -r REGION, --region REGION
-                        the AWS region in which to operate. If a region is not
-                        specified, credstash will use the value of the
-                        AWS_DEFAULT_REGION env variable, or if that is not
-                        set, us-east-1
-  -t TABLE, --table TABLE
-                        DynamoDB table to use for credential storage
-  -n ARN, --arn ARN     AWS IAM ARN for AssumeRole
-```
 ## IAM Policies
 
 ### Secret Writer
-You can put or write secrets to credstash by either using KMS Key Grants, KMS Key Policies, or IAM Policies. If you are using IAM Policies, the following IAM permissions are the minimum required to be able to put or write secrets:
-```
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "kms:GenerateDataKey"
-      ],
-      "Effect": "Allow",
-      "Resource": "arn:aws:kms:us-east-1:AWSACCOUNTID:key/KEY-GUID"
-    },
-    {
-      "Action": [
-        "dynamodb:PutItem"
-      ],
-      "Effect": "Allow",
-      "Resource": "arn:aws:dynamodb:us-east-1:AWSACCOUNTID:table/credential-store"
-    }
-  ]
-}
-```
-If you are using Key Policies or Grants, then the `kms:GenerateDataKey` is not required in the policy for the IAM user/group/role. Replace `AWSACCOUNTID` with the account ID for your table, and replace the KEY-GUID with the identifier for your KMS key (which you can find in the KMS console).
 
-### Secret Reader
-You can read secrets from credstash with the get or getall actions by either using KMS Key Grants, KMS Key Policies, or IAM Policies. If you are using IAM Policies, the following IAM permissions are the minimum required to be able to get or read secrets:
-```
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "kms:Decrypt"
-      ],
-      "Effect": "Allow",
-      "Resource": "arn:aws:kms:us-east-1:AWSACCOUNTID:key/KEY-GUID"
-    },
-    {
-      "Action": [
-        "dynamodb:GetItem",
-        "dynamodb:Query",
-        "dynamodb:Scan"
-      ],
-      "Effect": "Allow",
-      "Resource": "arn:aws:dynamodb:us-east-1:AWSACCOUNTID:table/credential-store"
-    }
-  ]
-}
-```
-If you are using Key Policies or Grants, then the `kms:Decrypt` is not required in the policy for the IAM user/group/role. Replace `AWSACCOUNTID` with the account ID for your table, and replace the KEY-GUID with the identifier for your KMS key (which you can find in the KMS console). Note that the `dynamodb:Scan` permission is not required if you do not use wildcards in your `get`s.
+You can put or write secrets to credstash by either using KMS Key Grants, KMS
+Key Policies, or IAM Policies. If you are using IAM Policies, the following
+IAM permissions are the minimum required to be able to put or write secrets.
 
-### Setup Permissions
-In order to run `credstash setup`, you will also need to be able to perform the following DDB operations:
-```
-{
-    "Version": "2012-10-17",
-    "Statement": [
+If using `credstash` and respectively DynamoDB for credential store:
+
+    {
+      "Version": "2012-10-17",
+      "Statement": [
         {
-            "Action": [
-                "dynamodb:CreateTable",
-                "dynamodb:DescribeTable"
-            ],
-            "Effect": "Allow",
-            "Resource": "arn:aws:dynamodb:us-west-2:<ACCOUNT NUMBER>:table/credential-store"
+          "Action": [
+            "kms:GenerateDataKey"
+          ],
+          "Effect": "Allow",
+          "Resource": "arn:aws:kms:us-east-1:AWSACCOUNTID:key/KEY-GUID"
         },
         {
-            "Action": [
-                "dynamodb:ListTables"
-            ],
-            "Effect": "Allow",
-            "Resource": "*"
+          "Action": [
+            "dynamodb:PutItem"
+          ],
+          "Effect": "Allow",
+          "Resource": "arn:aws:dynamodb:us-east-1:AWSACCOUNTID:table/credential-store"
         }
-    ]
-}
-```
+      ]
+    }
+
+If using `creds3` and respectively S3 for credential store:
+
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": [
+            "kms:GenerateDataKey"
+          ],
+          "Effect": "Allow",
+          "Resource": "arn:aws:kms:us-east-1:AWSACCOUNTID:key/KEY-GUID"
+        },
+        {
+          "Action": [
+            "s3:PutObject"
+          ],
+          "Effect": "Allow",
+          "Resource": "arn:aws:s3::::credential-store-AWSACCOUNTID"
+        }
+      ]
+    }
+
+If you are using Key Policies or Grants, then the `kms:GenerateDataKey`
+is not required in the policy for the IAM user/group/role.
+Replace `AWSACCOUNTID` with the account ID for your bucket, and replace
+the KEY-GUID with the identifier for your KMS key (which you can find in
+the KMS console).
+
+### Secret Reader
+
+You can read secrets from credstash with the get or getall actions by either
+using KMS Key Grants, KMS Key Policies, or IAM Policies. If you are using
+IAM Policies, the following IAM permissions are the minimum required to be
+able to get or read secrets:
+
+If using `credstash` and respectively DynamoDB for credential store:
+
+
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": [
+            "kms:Decrypt"
+          ],
+          "Effect": "Allow",
+          "Resource": "arn:aws:kms:us-east-1:AWSACCOUNTID:key/KEY-GUID"
+        },
+        {
+          "Action": [
+            "dynamodb:GetItem",
+            "dynamodb:Query",
+            "dynamodb:Scan"
+          ],
+          "Effect": "Allow",
+          "Resource": "arn:aws:dynamodb:us-east-1:AWSACCOUNTID:table/credential-store"
+        }
+      ]
+    }
+
+If using `creds3` and respectively S3 for credential store:
+
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": [
+            "kms:Decrypt"
+          ],
+          "Effect": "Allow",
+          "Resource": "arn:aws:kms:us-east-1:AWSACCOUNTID:key/KEY-GUID"
+        },
+        {
+          "Action": [
+            "s3:List*"
+          ],
+          "Effect": "Allow",
+          "Resource": "arn:aws:s3:::credential-store-AWSACCOUNTID"
+        },
+        {
+          "Action": [
+            "s3:GetObject",
+            "s3:List*"
+          ],
+          "Effect": "Allow",
+          "Resource": "arn:aws:s3:::credential-store-AWSACCOUNTID/*"
+        }
+      ]
+    }
+
+If you are using Key Policies or Grants, then the `kms:Decrypt` is not
+required in the policy for the IAM user/group/role.
+Replace `AWSACCOUNTID` with the account ID for your bucket name, and
+replace the KEY-GUID with the identifier for your KMS key
+(which you can find in the KMS console).
+
+### Setup Permissions
+
+In order to run `credstash setup`, you will also need to be able to perform
+the following operations.
+
+If using `credstash` and respectively DynamoDB for credential store:
+
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": [
+            "kms:Decrypt"
+          ],
+          "Effect": "Allow",
+          "Resource": "arn:aws:kms:us-east-1:AWSACCOUNTID:key/KEY-GUID"
+        },
+        {
+          "Action": [
+            "dynamodb:GetItem",
+            "dynamodb:Query",
+            "dynamodb:Scan"
+          ],
+          "Effect": "Allow",
+          "Resource": "arn:aws:dynamodb:us-east-1:AWSACCOUNTID:table/credential-store"
+        }
+      ]
+    }
+
+If using `creds3` and respectively S3 for credential store:
+
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Action": [
+                    "s3:CreateBucket",
+                    "s3:HeadBucket"
+                ],
+                "Effect": "Allow",
+                "Resource": "*"
+            }
+        ]
+    }
+
 
 ## Security Notes
-Any IAM principal who can get items from the credential store DDB table, and can call KMS.Decrypt, can read stored credentials.
 
-The target deployment-story for `credstash` is an EC2 instance running with an IAM role that has permissions to read the credential store and use the master key. Since IAM role credentials are vended by the instance metadata service, by default, any user on the system can fetch creds and use them to retrieve credentials. That means that by default, the instance boundary is the security boundary for this system. If you are worried about unauthorized users on your instance, you should take steps to secure access to the Instance Metadata Service (for example, use iptables to block connections to 169.254.169.254 except for privileged users). Also, because credstash is written in python, if an attacker can dump the memory of the credstash process, they may be able to recover credentials. This is a known issue, but again, in the target deployment case, the security boundary is assumed to be the instance boundary.
+Any IAM principal who can get items from the credential store, and
+can call KMS.Decrypt, can read stored credentials.
 
+The target deployment-story for `credstash` is an EC2 instance running with an
+IAM role that has permissions to read the credential store and use the master
+key. Since IAM role credentials are vended by the instance metadata service,
+by default, any user on the system can fetch creds and use them to retrieve
+credentials. That means that by default, the instance boundary is the security
+boundary for this system. If you are worried about unauthorized users on your
+instance, you should take steps to secure access to the Instance Metadata
+Service (for example, use iptables to block connections to 169.254.169.254
+except for privileged users).
+Also, because credstash is written in python, if an attacker can dump the memory
+of the credstash process, they may be able to recover credentials. This is a
+known issue, but again, in the target deployment case, the security boundary
+is assumed to be the instance boundary.
 
 ## Frequently Asked Questions (FAQ)
 
 ### 1. Where is the master key stored?
-The master key is stored in AWS Key Management Service (KMS), where it is stored in secure HSM-backed storage. The Master Key never leaves the KMS service.
+
+The master key is stored in AWS Key Management Service (KMS), where it is
+stored in secure HSM-backed storage. The Master Key never leaves the
+KMS service.
 
 ### 2. How is credential rotation handled?
-Every credential in the store has a version number. Whenever you want to a credential to a new value, you have to do a `put` with a new credential version. For example, if you have `foo` version 1 in the database, then to update `foo`, you can put version 2. You can either specify the version manually (i.e. `credstash put foo bar -v 2`), or you can use the `-a` flag, which will attempt to autoincrement the version number (for example, `credstash put foo baz -a`). Whenever you do a `get` operation, credstash will fetch the most recent (highest version) version of that credential. So, to do credential rotation, simply put a new version of the credential, and clients fetching the credential will get the new version.
+
+Every credential in the store has a version number. Whenever you want to a
+credential to a new value, you have to do a `put` with a new credential
+version. For example, if you have `foo` version 1 in the database, then to
+update `foo`, you can put version 2. You can either specify the version
+manually (i.e. `credstash put foo bar -v 2`), or you can use the `-a` flag,
+which will attempt to autoincrement the version number (for example,
+`credstash put foo baz -a`). Whenever you do a `get` operation, credstash will
+fetch the most recent (highest version) version of that credential.
+So, to do credential rotation, simply put a new version of the credential,
+and clients fetching the credential will get the new version.
 
 ### 3. How much do the AWS services needed to run credstash cost?
-tl;dr: If you are using less than 25 reads/sec and 25 writes per second on DDB today, it will cost ~$1/month to use credstash.
+
+Te short answer: it depends. The main key differentiator will be the choice
+of credential storage. See below for some qualitative answers in the
+respective sections.
+
+#### DynamoDB credential storage
+
+If you are using less than 25 reads/sec and 25 writes per second on DDB today,
+it will cost ~$1/month to use credstash.
 
 The master key in KMS costs $1 per month.
 
-The credential store DDB table uses 1 provisioned read and 1 provisioned write throughput, along with a small amount of actual storage. This falls well below the free tier for DDB (25 reads and 25 writes per second). If you are already a heavy DDB user and exceed the free tier, the credential store table will cost about $0.53 per month (mostly from the write throughput).
+The credential store DDB table uses 1 provisioned read and 1 provisioned write
+throughput, along with a small amount of actual storage. This falls well below
+the free tier for DDB (25 reads and 25 writes per second). If you are already
+a heavy DDB user and exceed the free tier, the credential store table will cost
+about $0.53 per month (mostly from the write throughput).
 
-If you are using credstash heavily and need to increase the provisioned reads/writes, you may incur additional charges. You can estimate your bill using the AWS Simple Monthly Calculator (http://calculator.s3.amazonaws.com/index.html#s=DYNAMODB).
+If you are using credstash heavily and need to increase the provisioned
+reads/writes, you may incur additional charges. You can estimate your bill
+using the
+[DynamoDB AWS Simple Monthly Calculator](http://calculator.s3.amazonaws.com/index.html#s=DYNAMODB).
 
-### 4. Why DynamoDB for the credential store? Why not S3?
-DDB fits the application really well. Having very low latency fetches are really nice if credstash is in the critical path of spinning up an application. Being able to turn throughput up or down based on load and requirements are also great things to have in a config management tool. Also, as credstash gets into more complex credential management functions, the query capabilities of DDB get super handy.
+#### S3 credential storage
 
-That said, S3 support may happen someday.
+If you are using less than 25 reads/hour and 2 writes per hour on
+S3 bucket today, it will cost ~$1/month to use credstash.
+
+The master key in KMS costs $1 per month.
+
+If you are using credstash heavily reads/writes, you may incur additional
+charges and might consider switching to using DynamoDB credential store and
+`credstash` command line interface instead of `creds3` (see above), as
+the DynamoDB has much more generous allowances for reads and writes.
+
+You can estimate your bill using the
+[S3 AWS Simple Monthly Calculator](http://calculator.s3.amazonaws.com/index.html#s=S3).
+
+### 4. What should I use for credential store: S3 or DynamoDB?
+
+DynamoDB fits the application really well. Having very low latency fetches
+are really nice if credstash is in the critical path of spinning up an
+application. Being able to turn throughput up or down based on load and
+requirements are also great things to have in a config management tool.
+Also, as credstash gets into more complex credential management functions,
+the query capabilities of DDB get super handy.
+
+Having said that, there might be cases where one is forced to use S3 for
+storing the secrets (the word 'enterprise' comes to mind). Under those or
+similar considerations, one might use S3 as their credential store and
+`creds3` command line interface for Credstash for that.
 
 ### 5. Where can I learn more about use cases and context for something like credstash?
-Check out this blog post: http://blog.fugue.it/2015-04-21-aws-kms-secrets.html
+
+Check out this [blog post](http://blog.fugue.it/2015-04-21-aws-kms-secrets.html)
+
+

--- a/creds3
+++ b/creds3
@@ -1,0 +1,1 @@
+creds3.py

--- a/creds3.py
+++ b/creds3.py
@@ -1,0 +1,543 @@
+#!/usr/bin/env python
+# Copyright 2015 DevOpsyTurvy
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import print_function
+
+from credstash import open_aes_ctr_legacy, seal_aes_ctr_legacy
+from credstash import get_session, get_session_params
+from credstash import get_assumerole_credentials
+from credstash import KeyService, KmsError, IntegrityError, ItemNotFound
+from credstash import KeyValueToDictionary, key_value_pair, expand_wildcard
+from credstash import fatal, value_or_filename
+from credstash import csv_dump, dotenv_dump
+from credstash import clean_fail
+from credstash import HASHING_ALGORITHMS, DEFAULT_DIGEST, DEFAULT_REGION
+from credstash import WILDCARD_CHAR
+import argparse
+import json
+import operator
+import os
+import os.path
+import sys
+import boto3
+import botocore.exceptions
+
+try:
+    import yaml
+    NO_YAML = False
+except ImportError:
+    NO_YAML = True
+
+def getHighestVersion(name, region=None, location=None,
+                      **kwargs):
+    '''
+    Return the highest version of `name` in the S3 location
+    '''
+
+    (bucket, prefix) = get_s3_bucket_prefix(location)
+    secrets = listSecrets(region, bucket + "/" + prefix + name, True, **kwargs)
+
+    if len(secrets) == 0:
+        return 0
+    return secrets[0]["version"]
+
+
+def listSecrets(region=None, location=None, only_latest=True, **kwargs):
+    '''
+    list all credentials stored in the S3 location,
+    and return the names and latest versions of every credential
+    '''
+    session = get_session(**kwargs)
+    client = session.client('s3', region_name=region)
+    (bucket, prefix) = get_s3_bucket_prefix(location)
+    response = client.list_objects_v2(Bucket=bucket,Prefix=prefix)
+    if response.get("Contents"):
+        # Get the list of all object in the S3 location
+        # sorted by the modification date in reverse order
+        secrets = sorted( [{ "name": item["Key"].split('/')[0], 
+            "version": item["Key"].split('/')[1], 
+            "datetime": item["LastModified"]} for item in response["Contents"] ],
+            key=lambda s: s["datetime"],
+            reverse=True)
+        if only_latest:
+            # Form an array with the latest versions of the objects only
+            saved = set()
+            saved_add = saved.add
+            latest = [ item for item in secrets
+                if not (item["name"] in saved or saved_add(item["name"])) ]
+        else:
+            latest = secrets
+    else:
+        latest = []
+
+    return latest
+
+
+def putSecret(name, secret, version="", kms_key="alias/creds3",
+              region=None, location=None, context=None,
+              digest=DEFAULT_DIGEST, **kwargs):
+    '''
+    put a secret called `name` into the secret-store,
+    protected by the key kms_key
+    '''
+    if not context:
+        context = {}
+    session = get_session(**kwargs)
+    kms = session.client('kms', region_name=region)
+    key_service = KeyService(kms, kms_key, context)
+    sealed = seal_aes_ctr_legacy(
+        key_service,
+        secret,
+        digest_method=digest,
+    )
+
+    client = session.client('s3', region_name=region)
+    (bucket, prefix) = get_s3_bucket_prefix(location)
+    version_exists = True
+    try:
+        obj = client.get_object(Bucket = bucket,
+            Key = prefix + name + "/" + version)
+    except botocore.exceptions.ClientError as e:
+        if e.response["Error"]["Code"] == "NoSuchKey":
+            client.put_object(Bucket = bucket,
+                  Key = prefix + name + "/" + version,
+                  Metadata = sealed[1],
+                  Body = sealed[0]
+                )
+            version_exists = False
+        else:
+            fatal(e)
+
+    if version_exists:
+        latestVersion = getHighestVersion(name, region,
+                                            location,
+                                            **kwargs)
+        fatal("%s version %s is already in the credential store. "
+                "Use the -v flag to specify a new version" %
+                (name, latestVersion))
+
+    return True
+
+
+def getAllSecrets(version="", region=None, location=None,
+                  context=None, credential=None, session=None, **kwargs):
+    '''
+    fetch and decrypt all secrets
+    '''
+    output = {}
+    if session is None:
+        session = get_session(**kwargs)
+
+    client = session.client('s3', region_name=region)
+    kms = session.client('kms', region_name=region)
+    secrets = listSecrets(region, location, True, **kwargs)
+
+    for secret in secrets:
+        credential = secret["name"]
+        try:
+            output[credential] = getSecret(credential,
+                                           version,
+                                           region,
+                                           location,
+                                           context,
+                                           client,
+                                           kms,
+                                           **kwargs)
+        except:
+            pass
+    return output
+
+
+@clean_fail
+def getAllAction(args, location, region, **session_params):
+    secrets = getAllSecrets(args.version,
+                            region=region,
+                            location=location,
+                            context=args.context,
+                            **session_params)
+    if args.format == "json":
+        output_func = json.dumps
+        output_args = {"sort_keys": True,
+                       "indent": 4,
+                       "separators": (',', ': ')}
+    elif not NO_YAML and args.format == "yaml":
+        output_func = yaml.dump
+        output_args = {"default_flow_style": False}
+    elif args.format == 'csv':
+        output_func = csv_dump
+        output_args = {}
+    elif args.format == 'dotenv':
+        output_func = dotenv_dump
+        output_args = {}
+    print(output_func(secrets, **output_args))
+
+
+@clean_fail
+def putSecretAction(args, location, region, **session_params):
+    if args.autoversion:
+        latestVersion = getHighestVersion(args.credential,
+                                          region,
+                                          location,
+                                          **session_params)
+        try:
+            version = str(int(latestVersion) + 1)
+        except ValueError:
+            fatal("Can not autoincrement version. The current "
+                  "version: %s is not an int" % latestVersion)
+    else:
+        version = args.version
+
+    try:
+        if putSecret(args.credential, args.value, version,
+                     kms_key=args.key, region=region, location=location,
+                     context=args.context, digest=args.digest,
+                     **session_params):
+            print("{0} has been stored".format(args.credential))
+    except KmsError as e:
+        fatal(e)
+    except botocore.exceptions.ClientError as e:
+        fatal(e)
+
+
+@clean_fail
+def getSecretAction(args, location, region, **session_params):
+    try:
+        if WILDCARD_CHAR in args.credential:
+            names = expand_wildcard(args.credential,
+                                    [x["name"]
+                                     for x
+                                     in listSecrets(region=region,
+                                                    location=location,
+                                                    only_latest=True,
+                                                    **session_params)])
+            print(json.dumps(dict((name,
+                                   getSecret(name,
+                                             args.version,
+                                             region=region,
+                                             location=location,
+                                             context=args.context,
+                                             **session_params))
+                                  for name in names)))
+        else:
+            sys.stdout.write(getSecret(args.credential, args.version,
+                                       region=region, location=location,
+                                       context=args.context,
+                                       **session_params))
+            if not args.noline:
+                sys.stdout.write("\n")
+    except ItemNotFound as e:
+        fatal(e)
+    except KmsError as e:
+        fatal(e)
+    except IntegrityError as e:
+        fatal(e)
+
+
+def getSecret(name, version="", region=None,
+              location=None, context=None,
+              client=None, kms=None, **kwargs):
+    '''
+    fetch and decrypt the secret called `name`
+    '''
+    if not context:
+        context = {}
+
+    # Can we cache
+    if client is None or kms is None:
+        session = get_session(**kwargs)
+        if client is None:
+            client = session.client('s3', region_name=region)
+        if kms is None:
+            kms = session.client('kms', region_name=region)
+
+    (bucket, prefix) = get_s3_bucket_prefix(location)
+
+    if version == "":
+        secrets = listSecrets(region, bucket + "/" + prefix + name,
+                True, **kwargs)
+        # do a consistent fetch of the credential with the highest version
+        if secrets:
+            obj = client.get_object(Bucket = bucket,
+                    Key = prefix + name + "/" + secrets[0]["version"])
+        else:
+            raise ItemNotFound("Item {'name': '%s'} couldn't be found in %s" %
+                    name, location)
+    else:
+        obj = client.get_object(Bucket = bucket,
+                    Key = prefix + name + "/" + version)
+    material = { "contents": obj["Body"].read() }
+    material.update(obj["Metadata"])
+
+    key_service = KeyService(kms, None, context)
+
+    return open_aes_ctr_legacy(key_service, material)
+
+
+def get_s3_bucket_prefix(location):
+    if location.find('/') > 0:
+        bucket = location[:location.find('/')]
+        prefix = location[location.find('/')+1:]
+        if prefix[-1] != '/':
+            prefix = prefix + '/'
+    else:
+        bucket = location
+        prefix = ''
+    return bucket, prefix
+
+@clean_fail
+def deleteSecrets(name, region=None, location=None, **kwargs):
+    session = get_session(**kwargs)
+    client = session.client('s3', region_name=region)
+    (bucket, prefix) = get_s3_bucket_prefix(location)
+    response = client.list_objects_v2(Bucket=bucket,Prefix=prefix + name)
+
+    for secret in response["Contents"]:
+        print("Deleting %s -- version %s" %
+              (name, secret["Key"]))
+        client.delete_object(Bucket=bucket,Key=secret["Key"])
+
+
+@clean_fail
+def createS3Bucket(region=None, location=None, **kwargs):
+    '''
+    create the secret store S3 bucket in the specified region
+    '''
+    session = get_session(**kwargs)
+    client = session.client("s3", region_name=region)
+    (bucket, prefix) = get_s3_bucket_prefix(location)
+
+    try:
+        response = client.create_bucket(ACL='private',
+                Bucket=bucket,
+                CreateBucketConfiguration={
+                    'LocationConstraint': region
+                })
+    except botocore.exceptions.ClientError as e:
+        if e.response["Error"]["Code"] == "BucketAlreadyOwnedByYou":
+            print("Credential Store bucket '%s' exists and owned by you" %
+                    bucket)
+        elif e.response["Error"]["Code"] == "BucketAlreadyExists":
+            print("Bucket '%s' exists already - please use another name" %
+                    bucket)
+            return
+        else:
+            fatal(e)
+
+    print("Checking the Credential Store bucket '%s' ..." % bucket)
+    response = client.head_bucket(Bucket=bucket)
+    customer_kms = response.get('ResponseMetadata').get('SSECustomerKeyMD5')
+    if customer_kms:
+        print("Looks like S3 bucket '%s' employs encryption with a "
+                "customer  KMS key %s" % (bucket, customer_kms))
+        print("This is not currently supported for Credential Store!")
+        fatal(" ".join(["Disable encryption with customer KMS for %s",
+                "or use different S3 bucket for Credential Store"]) % bucket)
+    print("Credential Store is ok. "
+          "Go read the README about how to create your KMS key")
+
+@clean_fail
+def list_credentials(region, location, **session_params):
+    credential_list = listSecrets(region=region,
+                                  location=location,
+                                  only_latest=False,
+                                  **session_params)
+    if credential_list:
+        # print list of credential names and versions,
+        # sorted by name and then by version
+        max_len = max([len(x["name"]) for x in credential_list])
+        for cred in sorted(credential_list,
+                           key=operator.itemgetter("name", "version")):
+            print("{0:{1}} -- version {2:>}".format(
+                cred["name"], max_len, cred["version"]))
+    else:
+        return
+
+def get_parser():
+    """get the parsers dict"""
+    parsers = {}
+    parsers['super'] = argparse.ArgumentParser(
+        description="A credential/secret storage system")
+
+    parsers['super'].add_argument("-r", "--region",
+                                  help="the AWS region in which to operate. "
+                                  "If a region is not specified, creds3h "
+                                  "will use the value of the "
+                                  "AWS_DEFAULT_REGION env variable, "
+                                  "or if that is not set, the value in "
+                                  "`~/.aws/config`. As a last resort, "
+                                  "it will use " + DEFAULT_REGION)
+    parsers['super'].add_argument("-l", "--location",
+                                  help="S3 location to use for "
+                                  "credential storage")
+    role_parse = parsers['super'].add_mutually_exclusive_group()
+    role_parse.add_argument("-p", "--profile", default=None,
+                            help="Boto config profile to use when "
+                            "connecting to AWS")
+    role_parse.add_argument("-n", "--arn", default=None,
+                            help="AWS IAM ARN for AssumeRole")
+    subparsers = parsers['super'].add_subparsers(help='Try commands like '
+                                                 '"{name} get -h" or "{name} '
+                                                 'put --help" to get each '
+                                                 'sub command\'s options'
+                                                 .format(name=sys.argv[0]))
+
+    action = 'delete'
+    parsers[action] = subparsers.add_parser(action,
+                                 help='Delete a credential from the store')
+    parsers[action].add_argument("credential", type=str,
+                                 help="the name of the credential to delete")
+    parsers[action].set_defaults(action=action)
+
+    action = 'get'
+    parsers[action] = subparsers.add_parser(action, help="Get a credential "
+                                            "from the store")
+    parsers[action].add_argument("credential", type=str,
+                                 help="the name of the credential to get."
+                                 "Using the wildcard character '%s' will "
+                                 "search for credentials that match the "
+                                 "pattern" % WILDCARD_CHAR)
+    parsers[action].add_argument("context", type=key_value_pair,
+                                 action=KeyValueToDictionary, nargs='*',
+                                 help="encryption context key/value pairs "
+                                 "associated with the credential in the form "
+                                 "of \"key=value\"")
+    parsers[action].add_argument("-n", "--noline", action="store_true",
+                                 help="Don't append newline to returned "
+                                 "value (useful in scripts or with "
+                                 "binary files)")
+    parsers[action].add_argument("-v", "--version", default="",
+                                 help="Get a specific version of the "
+                                 "credential (defaults to the latest version)")
+    parsers[action].set_defaults(action=action)
+
+    action = 'getall'
+    parsers[action] = subparsers.add_parser(action,
+                                            help="Get all credentials from "
+                                            "the store")
+    parsers[action].add_argument("context", type=key_value_pair,
+                                 action=KeyValueToDictionary, nargs='*',
+                                 help="encryption context key/value pairs "
+                                 "associated with the credential in the form "
+                                 "of \"key=value\"")
+    parsers[action].add_argument("-v", "--version", default="",
+                                 help="Get a specific version of the "
+                                 "credential (defaults to the latest version)")
+    parsers[action].add_argument("-f", "--format", default="json",
+                                 choices=["json", "csv", "dotenv"] +
+                                 ([] if NO_YAML else ["yaml"]),
+                                 help="Output format. json(default) " +
+                                 ("" if NO_YAML else "yaml ") + " csv or dotenv.")
+    parsers[action].set_defaults(action=action)
+
+    action = 'list'
+    parsers[action] = subparsers.add_parser(action,
+                                            help="list credentials and "
+                                            "their versions")
+    parsers[action].set_defaults(action=action)
+
+    action = 'put'
+    parsers[action] = subparsers.add_parser(action,
+                                            help="Put a credential into "
+                                            "the store")
+    parsers[action].add_argument("credential", type=str,
+                                 help="the name of the credential to store")
+    parsers[action].add_argument("value", type=value_or_filename,
+                                 help="the value of the credential to store "
+                                 "or, if beginning with the \"@\" character, "
+                                 "the filename of the file containing "
+                                 "the value, or pass \"-\" to read the value "
+                                 "from stdin", default="")
+    parsers[action].add_argument("context", type=key_value_pair,
+                                 action=KeyValueToDictionary, nargs='*',
+                                 help="encryption context key/value pairs "
+                                 "associated with the credential in the form "
+                                 "of \"key=value\"")
+    parsers[action].add_argument("-k", "--key", default="alias/creds3",
+                                 help="the KMS key-id of the master key "
+                                 "to use. See the README for more "
+                                 "information. Defaults to alias/creds3")
+    parsers[action].add_argument("-v", "--version", default="1",
+                                 help="Put a specific version of the "
+                                 "credential (update the credential; "
+                                 "defaults to version `1`).")
+    parsers[action].add_argument("-a", "--autoversion", action="store_true",
+                                 help="Automatically increment the version of "
+                                 "the credential to be stored. This option "
+                                 "causes the `-v` flag to be ignored. "
+                                 "(This option will fail if the currently stored "
+                                 "version is not numeric.)")
+    parsers[action].add_argument("-d", "--digest", default=DEFAULT_DIGEST,
+                                 choices=HASHING_ALGORITHMS,
+                                 help="the hashing algorithm used to "
+                                 "to encrypt the data. Defaults to SHA256")
+    parsers[action].set_defaults(action=action)
+
+    action = 'setup'
+    parsers[action] = subparsers.add_parser(action,
+                                            help='setup the credential store')
+    parsers[action].set_defaults(action=action)
+    return parsers
+
+def get_aws_account_id(session):
+    sts = session.client("sts")
+    user_arn = sts.get_caller_identity()["Arn"]
+    return user_arn.split(":")[4]
+
+def main():
+    parsers = get_parser()
+    args = parsers['super'].parse_args()
+
+    # Check for assume role and set  session params
+    session_params = get_session_params(args.profile, args.arn)
+
+    try:
+        region = args.region
+        session = get_session(**session_params)
+        session.client('s3', region_name=region)
+        account_id = get_aws_account_id(session)
+    except botocore.exceptions.NoRegionError:
+        if 'AWS_DEFAULT_REGION' not in os.environ:
+            region = DEFAULT_REGION
+
+    location = args.location if args.location \
+            else "credential-store-" + account_id
+
+    if "action" in vars(args):
+        if args.action == "delete":
+            deleteSecrets(args.credential,
+                          region=region,
+                          location=location,
+                          **session_params)
+            return
+        if args.action == "list":
+            list_credentials(region, location, **session_params)
+            return
+        if args.action == "put":
+            putSecretAction(args, location, region, **session_params)
+            return
+        if args.action == "get":
+            getSecretAction(args, location, region, **session_params)
+            return
+        if args.action == "getall":
+            getAllAction(args, location, region, **session_params)
+            return
+        if args.action == "setup":
+            createS3Bucket(region=region, location=location,
+                           **session_params)
+            return
+    else:
+        parsers['super'].print_help()
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@ from setuptools import setup
 
 setup(
     name='credstash',
-    version='1.13.2',
-    description='A utility for managing secrets in the cloud using AWS KMS and DynamoDB',
+    version='1.14.0',
+    description='Utilities for managing secrets in the cloud using AWS KMS and DynamoDB or S3',
     license='Apache2',
     url='https://github.com/LuminalOSS/credstash',
     classifiers=[
@@ -11,7 +11,7 @@ setup(
         'Intended Audience :: System Administrators',
         'License :: OSI Approved :: Apache Software License',
     ],
-    scripts=['credstash.py'],
+    scripts=['credstash.py, creds3.py'],
     py_modules=['credstash'],
     install_requires=[
         'cryptography>=1.5, <2.0',
@@ -22,7 +22,9 @@ setup(
     },
     entry_points={
         'console_scripts': [
-            'credstash = credstash:main'
+            'credstash = credstash:main',
+            'creds3 = creds3:main'
         ]
-    }
+    },
+    obsoletes=[ 'creds3' ]
 )


### PR DESCRIPTION
Hi Alex, 

I cloned your excellent tool Credstash and modified the code to use S3 instead of DynamoDB as a separate repo (see [creds3](https://github.com/romanrev/creds3)) as I did not have enough time to work on a PR to the existing code and I needed the package out ASAP.
I don't like duplicating code, however so here's the PR to merge all the changes to make sure they live there where they belong and also to obsolete the `creds3` package once this version is released.

Thank you!