### PR TITLE
Add option to list unique keys

### DIFF
--- a/credstash.py
+++ b/credstash.py
@@ -748,6 +748,11 @@ def get_parser():
                                  ("" if NO_YAML else "yaml ") + " csv or dotenv.")
     parsers[action].set_defaults(action=action)
 
+    action = 'keys'
+    parsers[action] = subparsers.add_parser(action,
+                                            help="List all keys in the store")
+    parsers[action].set_defaults(action=action)
+
     action = 'list'
     parsers[action] = subparsers.add_parser(action,
                                             help="list credentials and "

--- a/credstash.py
+++ b/credstash.py
@@ -649,6 +649,19 @@ def list_credentials(region, args, **session_params):
         return
 
 
+@clean_fail
+def list_credential_keys(region, args, **session_params):
+    credential_list = listSecrets(region=region,
+                                  table=args.table,
+                                  **session_params)
+    if credential_list:
+        creds = sorted(set([cred["name"] for cred in credential_list]))
+        for cred in creds:
+            print(cred)
+    else:
+        return
+
+
 def get_session_params(profile, arn):
     params = {}
     if profile is None and arn:
@@ -809,6 +822,9 @@ def main():
             return
         if args.action == "list":
             list_credentials(region, args, **session_params)
+            return
+        if args.action == "keys":
+            list_credential_keys(region, args, **session_params)
             return
         if args.action == "put":
             putSecretAction(args, region, **session_params)


### PR DESCRIPTION
I often find that I want to know what keys exist, but not how many versions.
This adds `credstash keys` to just print out the list of credentials without versions.