### PR TITLE
Remove <2.0 cryptography constraint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-cryptography>=1.5, <2.0
+cryptography>=1.5
 boto3>=1.1.1

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     scripts=['credstash.py'],
     py_modules=['credstash'],
     install_requires=[
-        'cryptography>=1.5, <2.0',
+        'cryptography>=1.5',
         'boto3>=1.1.1',
     ],
     extras_require={


### PR DESCRIPTION
The [update to Cryptography today](https://cryptography.io/en/latest/changelog/#id1) broke our builds.

Is this something you would consider merging posthaste? It would be *very* appreciated!

I tested `get` and `put` commands via the `credstash` CLI to verify that this can be done safely. I'm uncertain though if this change has further implications. I just assumed that it is some legacy holdover.

Thanks!