### PR TITLE
paginate results when data returned is greater than 1MB

### DIFF
--- a/credstash.py
+++ b/credstash.py
@@ -261,7 +261,18 @@ def listSecrets(region=None, table="credential-store", **kwargs):
 
     response = secrets.scan(ProjectionExpression="#N, version",
                             ExpressionAttributeNames={"#N": "name"})
-    return response["Items"]
+    # print(response)
+    items = []
+
+    response = secrets.scan(ProjectionExpression="#N, version",
+                            ExpressionAttributeNames={"#N": "name"})
+    items = response["Items"]
+    while 'LastEvaluatedKey' in response:
+        response = secrets.scan(ProjectionExpression="#N, version",
+                                ExpressionAttributeNames={"#N": "name"},
+                                ExclusiveStartKey=response['LastEvaluatedKey'])
+        items.extend(response['Items'])
+    return items
 
 
 def putSecret(name, secret, version="", kms_key="alias/credstash",


### PR DESCRIPTION
As per the DynamoDB boto3 docs
(http://boto3.readthedocs.io/en/latest/reference/services/dynamodb.html#DynamoDB.Client.scan)
if the LastEvaluatedKey is in the response there are more results to
return. This implements using that to ensure all results are returned.

Should fix #172 