### PR TITLE
Force cryptography<2.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-cryptography>=1.5
+cryptography>=1.5,<2.1
 boto3>=1.1.1

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     scripts=['credstash.py'],
     py_modules=['credstash'],
     install_requires=[
-        'cryptography>=1.5',
+        'cryptography>=1.5, <2.1',
         'boto3>=1.1.1',
     ],
     extras_require={


### PR DESCRIPTION
In version 2.1 of cryptography, support for RIPEMD160 hashes got removed (see cryptography [`master`](https://github.com/pyca/cryptography/blob/master/src/cryptography/hazmat/primitives/hashes.py#L145)  vs [`2.0.x`](https://github.com/pyca/cryptography/blob/2.0.x/src/cryptography/hazmat/primitives/hashes.py#L145) ), but Credstash still points to those.
I chose to modify setup.py rather than remove that hash family from credstash, as that would probably be disruptive for other users of `credstash`.