### PR TITLE
Remove unsupported hashing methods.

### DIFF
--- a/credstash.py
+++ b/credstash.py
@@ -52,8 +52,6 @@ _hash_classes = {
     'SHA256': hashes.SHA256,
     'SHA384': hashes.SHA384,
     'SHA512': hashes.SHA512,
-    'RIPEMD': hashes.RIPEMD160,
-    'WHIRLPOOL': hashes.Whirlpool,
     'MD5': hashes.MD5,
 }
 


### PR DESCRIPTION
Support of Whirlpool and RIPEMD160 hashing methods was removed in
cryptography.hazmat.primitives.
https://github.com/pyca/cryptography/commit/0d6aaf49c1890378ce7ecf741a3a40c859d3b9fb