### PR TITLE
Remove cryptography constraints, remove RIPEMD support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,8 @@ language: python
 python:
   - "2.6"
   - "2.7"
-  - "3.3"
   - "3.4"
   - "pypy-5.4"
 install:
   - pip install -r requirements.txt
-script: nosetests 
+script: nosetests

--- a/credstash.py
+++ b/credstash.py
@@ -52,7 +52,6 @@ _hash_classes = {
     'SHA256': hashes.SHA256,
     'SHA384': hashes.SHA384,
     'SHA512': hashes.SHA512,
-    'RIPEMD': hashes.RIPEMD160,
     'WHIRLPOOL': hashes.Whirlpool,
     'MD5': hashes.MD5,
 }

--- a/credstash.py
+++ b/credstash.py
@@ -52,7 +52,6 @@ _hash_classes = {
     'SHA256': hashes.SHA256,
     'SHA384': hashes.SHA384,
     'SHA512': hashes.SHA512,
-    'WHIRLPOOL': hashes.Whirlpool,
     'MD5': hashes.MD5,
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-cryptography>=1.5,<2.1
+cryptography>=1.5
 boto3>=1.1.1

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     scripts=['credstash.py'],
     py_modules=['credstash'],
     install_requires=[
-        'cryptography>=1.5, <2.1',
+        'cryptography>=1.5',
         'boto3>=1.1.1',
     ],
     extras_require={


### PR DESCRIPTION
This _should_ solve the failed builds caused from reconciliation issues with other third party libraries that include `cryptography` (e.g. `pyOpenSSL`).

It's probably better to allow `cryptography` to dictate the deprecation of encryption algorithms anyway, rather than stymie progress in favor of legacy backwards compatibility.