### PR TITLE
Resolves #102: Adds os-specific newline characters

### DIFF
--- a/credstash.py
+++ b/credstash.py
@@ -188,7 +188,7 @@ def value_or_filename(string):
 
 def csv_dump(dictionary):
     csvfile = StringIO()
-    csvwriter = csv.writer(csvfile)
+    csvwriter = csv.writer(csvfile, lineterminator=os.linesep)
     for key in dictionary:
         csvwriter.writerow([key, dictionary[key]])
     return csvfile.getvalue()


### PR DESCRIPTION
I'm not sure how to write tests for this in a cross-platform manner. Is it possible to change which operating system a python script thinks it is in at runtime?

I did confirm this change adds the appropriate line ending for my linux machine:

```
# Before change
$ credstash getall -f csv > blah.txt
$ ag "\r\n"
blah.txt
1:kek,test
2:test.ca-pemfile.crl,test
3:test.server-cert.crt,test
4:test.client-ca.crt,test
5:manufacturerKey,test
6:test.server-cert.key,test
7:

# After change
$ credstash getall -f csv > blah.txt
$ ag "\r\n"
```