### PR TITLE
Resolves #93: Uses boto3 to find region if possible

### DIFF
--- a/credstash.py
+++ b/credstash.py
@@ -791,14 +791,13 @@ def main():
 
     # Check for assume role and set  session params
     session_params = get_session_params(args.profile, args.arn)
+    region = args.region if args.region else None
 
     try:
-        region = args.region
         session = get_session(**session_params)
         session.resource('dynamodb', region_name=region)
     except botocore.exceptions.NoRegionError:
-        if 'AWS_DEFAULT_REGION' not in os.environ:
-            region = DEFAULT_REGION
+        region = DEFAULT_REGION
 
     if "action" in vars(args):
         if args.action == "delete":


### PR DESCRIPTION
Rather than depending on the partially implemented `AWS_DEFAULT_REGION`
check, this change makes it so credstash relies more heavily on boto3 to
discover regions. Now we can do things like define an `~/.aws/config`
file that looks like this:

```ini
[profile work]
region=us-west-2
```

and run credstash like this:

```command
AWS_PROFILE=work credstash -n arn:aws:iam::000000000000:role/some-role get test
```

and it will successfully find the correct region

Only in the case where the region is absolutely not found, does
credstash then default to `us-east-1`. It's slightly backward
incompatible, but I think it's a nice improvement.