### PR TITLE
Add quotes for dotenv output

### DIFF
--- a/credstash.py
+++ b/credstash.py
@@ -197,7 +197,7 @@ def csv_dump(dictionary):
 def dotenv_dump(dictionary):
     dotenv_buffer = StringIO()
     for key in dictionary:
-        dotenv_buffer.write("%s=%s\n" % (key.upper(), dictionary[key]))
+        dotenv_buffer.write("%s='%s'\n" % (key.upper(), dictionary[key]))
     dotenv_buffer.seek(0)
     return dotenv_buffer.read()
 


### PR DESCRIPTION
This PR adds quotes for the key/value pairs ouptut with the dotenv output format.  The new output will now look like:

```
key='value'
key2='other value'
```