### PR TITLE
Add comment option to the put all operation

### DIFF
--- a/credstash.py
+++ b/credstash.py
@@ -866,6 +866,9 @@ def get_parser():
                                  help="Put a specific version of the "
                                       "credential (update the credential; "
                                       "defaults to version `1`).")
+    parsers[action].add_argument("-c", "--comment", type=str,
+                                 help="Include reference information or a comment about "
+                                 "value to be stored.")
     parsers[action].add_argument("-a", "--autoversion", action="store_true",
                                  help="Automatically increment the version of "
                                       "the credential to be stored. This option "


### PR DESCRIPTION
Currently running the `put all` operation leads to this error: 
```
"credstash.py”, line 386, in putSecretAction
   context=args.context, digest=args.digest, comment=args.comment,
AttributeError: ‘Namespace’ object has no attribute ‘comment’
```

This is because the comment is not an argument for the putall operation but `put` is expecting `comment`.
Adding the comment to the putall operation solves the problem and it also makes sense to add a comment in the bulk put operation.