### PR TITLE
Set args.comment to None when using putall.

### DIFF
--- a/credstash.py
+++ b/credstash.py
@@ -408,6 +408,7 @@ def putAllSecretsAction(args, region, **session_params):
         try:
             args.credential = credential
             args.value = value
+            args.comment = None
             putSecretAction(args, region, **session_params)
         except SystemExit as e:
             pass


### PR DESCRIPTION
Fixes fugue/credstash#218.