### PR TITLE
Ability to tag new tables, Resolves #233

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ positional arguments:
 
 
 setup
-    usage: credstash setup [-h] [-r REGION] [-t TABLE] [-p PROFILE | -n ARN]
+    usage: credstash setup [-h] [--tags [TAGS [TAGS ...]]] [-r REGION] [-t TABLE] [-p PROFILE | -n ARN]
 
 optional arguments:
   -r REGION, --region REGION

--- a/credstash.py
+++ b/credstash.py
@@ -148,7 +148,7 @@ def fatal(s):
 
 def key_value_pair(string):
     output = string.split('=')
-    if len(output) != 2:
+    if len(output) != 2 or '' in output:
         msg = "%r is not the form of \"key=value\"" % string
         raise argparse.ArgumentTypeError(msg)
     return output
@@ -911,7 +911,7 @@ def get_parser():
     action = 'setup'
     parsers[action] = subparsers.add_parser(action,
                                             help='setup the credential store')
-    parsers[action].add_argument("--tags",
+    parsers[action].add_argument("--tags", type=key_value_pair,
                                   help="Tags to apply to the Dynamodb Table"
                                   "passed in as a space sparated list of Key=Value", nargs="*")
     parsers[action].set_defaults(action=action)

--- a/credstash.py
+++ b/credstash.py
@@ -523,7 +523,7 @@ def deleteSecrets(name, region=None, table="credential-store",
 
 
 @clean_fail
-def createDdbTable(region=None, table="credential-store", **kwargs):
+def createDdbTable(region=None, table="credential-store", tags=None, **kwargs):
     '''
     create the secret store table in DDB in the specified region
     '''
@@ -569,7 +569,7 @@ def createDdbTable(region=None, table="credential-store", **kwargs):
 
     client.get_waiter("table_exists").wait(TableName=table)
 
-    print("Adding tag...")
+    print("Adding tags...")
 
     client.tag_resource(
         ResourceArn=response["Table"]["TableArn"],
@@ -580,6 +580,16 @@ def createDdbTable(region=None, table="credential-store", **kwargs):
             },
         ]
     )
+
+    if tags:
+        tagset = []
+        for i in tags:
+            tag = i.split('=')
+            tagset.append({'Key': tag[0], 'Value': tag[1]})
+        client.tag_resource(
+            ResourceArn=response["Table"]["TableArn"],
+            Tags=tagset
+        )
 
     print("Table has been created. "
           "Go read the README about how to create your KMS key")
@@ -901,6 +911,9 @@ def get_parser():
     action = 'setup'
     parsers[action] = subparsers.add_parser(action,
                                             help='setup the credential store')
+    parsers[action].add_argument("--tags",
+                                  help="Tags to apply to the Dynamodb Table"
+                                  "passed in as a space sparated list of Key=Value", nargs="*")
     parsers[action].set_defaults(action=action)
     return parsers
 
@@ -947,7 +960,7 @@ def main():
             return
         if args.action == "setup":
             createDdbTable(region=region, table=args.table,
-                           **session_params)
+                           tags=args.tags, **session_params)
             return
     else:
         parsers['super'].print_help()

--- a/credstash.py
+++ b/credstash.py
@@ -912,7 +912,7 @@ def get_parser():
     parsers[action] = subparsers.add_parser(action,
                                             help='setup the credential store')
     parsers[action].add_argument("--tags", type=key_value_pair,
-                                  help="Tags to apply to the Dynamodb Table"
+                                  help="Tags to apply to the Dynamodb Table "
                                   "passed in as a space sparated list of Key=Value", nargs="*")
     parsers[action].set_defaults(action=action)
     return parsers

--- a/tests/key_pair_tests.py
+++ b/tests/key_pair_tests.py
@@ -12,7 +12,11 @@ class TestKeyValuePairExtraction(unittest.TestCase):
         self.assertRaises(argparse.ArgumentTypeError, key_value_pair, "")
 
     def test_key_value_pair_has_one_equals(self):
-        self.assertEqual(key_value_pair("="), ["", ""])
+        self.assertRaises(argparse.ArgumentTypeError, key_value_pair, "key1=key2=key3")
+
+    def test_key_value_pair_has_both_key_and_value(self):
+        self.assertRaises(argparse.ArgumentTypeError, key_value_pair, "key=")
+        self.assertRaises(argparse.ArgumentTypeError, key_value_pair, "=value")
 
     def test_key_value_pair_has_one_equals_with_values(self):
         self.assertEqual(key_value_pair("key1=value1"), ["key1", "value1"])


### PR DESCRIPTION
adds a `--tags` to `credstash setup`

Can be used as `credstash -t some-new-table setup --tags MyTag=MyValue AnotherTag=AnotherValue`