### PR TITLE
Be able to pass kms/dynamodb client to putSecret like we can with get…

### DIFF
--- a/credstash.py
+++ b/credstash.py
@@ -281,15 +281,21 @@ def listSecrets(region=None, table="credential-store", **kwargs):
 
 def putSecret(name, secret, version="", kms_key="alias/credstash",
               region=None, table="credential-store", context=None,
-              digest=DEFAULT_DIGEST, comment="", **kwargs):
+              digest=DEFAULT_DIGEST, comment="", kms=None, dynamodb=None, **kwargs):
     '''
     put a secret called `name` into the secret-store,
     protected by the key kms_key
     '''
     if not context:
         context = {}
-    session = get_session(**kwargs)
-    kms = session.client('kms', region_name=region)
+
+    if dynamodb is None or kms is None:
+        session = get_session(**kwargs)
+        if dynamodb is None:
+            dynamodb = session.resource('dynamodb', region_name=region)
+        if kms is None:
+            kms = session.client('kms', region_name=region)
+
     key_service = KeyService(kms, kms_key, context)
     sealed = seal_aes_ctr_legacy(
         key_service,
@@ -297,7 +303,6 @@ def putSecret(name, secret, version="", kms_key="alias/credstash",
         digest_method=digest,
     )
 
-    dynamodb = session.resource('dynamodb', region_name=region)
     secrets = dynamodb.Table(table)
 
     data = {


### PR DESCRIPTION
I use credstash.py as a module for my own code.  The getSecret method allows me to pass my own instance of the kms and dynamodb client sessions, however putSecret does not.  This brings that feature parity to putSecret. 