### PR TITLE
putall fails because prompt attribute is missing

### DIFF
--- a/credstash.py
+++ b/credstash.py
@@ -436,6 +436,7 @@ def putAllSecretsAction(args, region, **session_params):
             args.credential = credential
             args.value = value
             args.comment = None
+            args.prompt = None
             putSecretAction(args, region, **session_params)
         except SystemExit as e:
             pass


### PR DESCRIPTION
AttributeError: 'Namespace' object has no attribute 'prompt'

It's not needed for this operation anyhow.