### PR TITLE
Fix SyntaxWarnings showing up in python 3.8

### DIFF
--- a/credstash.py
+++ b/credstash.py
@@ -108,7 +108,7 @@ class KeyService(object):
 class KmsError(Exception):
 
     def __init__(self, value=""):
-        self.value = "KMS ERROR: " + value if value is not "" else "KMS ERROR"
+        self.value = "KMS ERROR: " + value if value != "" else "KMS ERROR"
 
     def __str__(self):
         return self.value
@@ -117,7 +117,7 @@ class KmsError(Exception):
 class IntegrityError(Exception):
 
     def __init__(self, value=""):
-        self.value = "INTEGRITY ERROR: " + value if value is not "" else \
+        self.value = "INTEGRITY ERROR: " + value if value != "" else \
                      "INTEGRITY ERROR"
 
     def __str__(self):


### PR DESCRIPTION
Hi guys,

Thanks for this software.
We recently upgraded our python to 3.8 to test the compatibility and when running credstash we get the following warnings:
```
/usr/local/bin/credstash.py:111: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  self.value = "KMS ERROR: " + value if value is not "" else "KMS ERROR"
/usr/local/bin/credstash.py:120: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  self.value = "INTEGRITY ERROR: " + value if value is not "" else \
```

This PR fixes those.

These warnings are problematic when you use the result of the credstash output in a variable using `$()`.
Thanks