### PR TITLE
Issue #256 Add configurable logging and log ALL exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ optional arguments:
 	                    it will use us-east-1
   --log-level LOG_LEVEL
                         Set the log level, default WARNING
-  -log-file LOG_FILE    Set the log output file, default credstash.log. Errors
+  --log-file LOG_FILE    Set the log output file, default credstash.log. Errors
                         are printed to stderr and stack traces are logged to
                         file                      
   -t TABLE, --table TABLE

--- a/README.md
+++ b/README.md
@@ -215,6 +215,11 @@ optional arguments:
 	                    AWS_DEFAULT_REGION env variable, or if that is not
 	                    set, the value in `~/.aws/config`. As a last resort,
 	                    it will use us-east-1
+  --log-level LOG_LEVEL
+                        Set the log level, default WARNING
+  -log-file LOG_FILE    Set the log output file, default credstash.log. Errors
+                        are printed to stderr and stack traces are logged to
+                        file                      
   -t TABLE, --table TABLE
 	                    DynamoDB table to use for credential storage
   -p PROFILE, --profile PROFILE

--- a/credstash.py
+++ b/credstash.py
@@ -270,6 +270,7 @@ def clean_fail(func):
     return func_wrapper
 
 
+@clean_fail
 def listSecrets(region=None, table="credential-store", session=None, **kwargs):
     '''
     do a full-table scan of the credential-store,
@@ -298,7 +299,7 @@ def listSecrets(region=None, table="credential-store", session=None, **kwargs):
 
     return items
 
-
+@clean_fail
 def putSecret(name, secret, version="", kms_key="alias/credstash",
               region=None, table="credential-store", context=None,
               digest=DEFAULT_DIGEST, comment="", kms=None, dynamodb=None, **kwargs):
@@ -509,7 +510,7 @@ def getSecretAction(args, region, **session_params):
     except IntegrityError as e:
         fatal(e)
 
-
+@clean_fail
 def getSecret(name, version="", region=None,
               table="credential-store", context=None,
               dynamodb=None, kms=None, **kwargs):
@@ -999,6 +1000,7 @@ def main():
     # Check for assume role and set  session params
     session_params = get_session_params(args.profile, args.arn)
 
+    # test for region
     try:
         region = args.region
         session = get_session(**session_params)

--- a/credstash.py
+++ b/credstash.py
@@ -819,7 +819,7 @@ def get_parser():
         help="Set the log level, default WARNING",
         default='WARNING'
     )
-    parsers['super'].add_argument("-log-file",
+    parsers['super'].add_argument("--log-file",
         help="Set the log output file, default credstash.log. Errors are "
         "printed to stderr and stack traces are logged to file",
         default='credstash.log'


### PR DESCRIPTION
References #256 

Currently, `credstash` only handles AWS ClientErrors by logging the error message to `stderr`. This is sufficient for most AWS errors, but doesn't handle non-AWS errors. This PR adds exception handling for all exceptions, and adds a configurable log file that includes the full stack trace.