### PR TITLE
Alias cached sessions

### DIFF
--- a/credstash.py
+++ b/credstash.py
@@ -633,13 +633,20 @@ def createDdbTable(region=None, table="credential-store", tags=None, **kwargs):
 
 def get_session(aws_access_key_id=None, aws_secret_access_key=None,
                 aws_session_token=None, profile_name=None):
-    if get_session._cached_session is None:
-        get_session._cached_session = boto3.Session(aws_access_key_id=aws_access_key_id,
-                                                    aws_secret_access_key=aws_secret_access_key,
-                                                    aws_session_token=aws_session_token,
-                                                    profile_name=profile_name)
-    return get_session._cached_session
-get_session._cached_session = None
+    if aws_access_key_id is not None:
+        if aws_access_key_id not in get_session._cached_sessions:
+            get_session._cached_sessions[aws_access_key_id] = boto3.Session(
+                aws_access_key_id=aws_access_key_id,
+                aws_secret_access_key=aws_secret_access_key,
+                aws_session_token=aws_session_token,
+                profile_name=profile_name
+            )
+        get_session._last_session = get_session._cached_sessions[aws_access_key_id]
+        return get_session._cached_sessions[aws_access_key_id]
+    else:
+        return get_session._last_session
+get_session._cached_sessions = {}
+get_session._last_session = None
 
 
 def get_assumerole_credentials(arn):

--- a/credstash.py
+++ b/credstash.py
@@ -648,6 +648,10 @@ def get_session(aws_access_key_id=None, aws_secret_access_key=None,
 get_session._cached_sessions = {}
 get_session._last_session = None
 
+def reset_sessions():
+    get_session._cached_sessions = {}
+    get_session._last_session = None
+
 
 def get_assumerole_credentials(arn):
     sts_client = boto3.client('sts')

--- a/credstash.py
+++ b/credstash.py
@@ -644,6 +644,8 @@ def get_session(aws_access_key_id=None, aws_secret_access_key=None,
         get_session._last_session = get_session._cached_sessions[aws_access_key_id]
         return get_session._cached_sessions[aws_access_key_id]
     else:
+        if get_session._last_session is None:
+            get_session._last_session = boto3.Session()
         return get_session._last_session
 get_session._cached_sessions = {}
 get_session._last_session = None

--- a/tests/get_session_tests.py
+++ b/tests/get_session_tests.py
@@ -1,0 +1,62 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from credstash import get_session
+
+class TestGetSession(unittest.TestCase):
+    def setUp(self):
+        get_session._cached_sessions = {}
+        get_session._last_session = None
+
+    @patch('boto3.Session')
+    def test_get_session_initial_session(self, mock_session):
+        mock_session.return_value = 'session1'
+        get_session(
+            aws_access_key_id='session1'
+        )
+        mock_session.assert_called_once_with(
+            aws_access_key_id='session1',
+            aws_secret_access_key=None,
+            aws_session_token=None,
+            profile_name=None
+        )
+
+    @patch('boto3.Session')
+    def test_get_session_single_last_session(self, mock_session):
+        mock_session.return_value = 'session1'
+        get_session(
+            aws_access_key_id='session1'
+        )
+        mock_session.assert_called_once_with(
+            aws_access_key_id='session1',
+            aws_secret_access_key=None,
+            aws_session_token=None,
+            profile_name=None
+        )
+        self.assertEqual(get_session(), 'session1')
+
+    @patch('boto3.Session')
+    def test_get_session_two_sessions(self, mock_session):
+        mock_session.side_effect = ['session1', 'session2']
+        get_session(
+            aws_access_key_id='session1'
+        )
+        mock_session.assert_called_with(
+            aws_access_key_id='session1',
+            aws_secret_access_key=None,
+            aws_session_token=None,
+            profile_name=None
+        )
+        get_session(
+            aws_access_key_id='session2'
+        )
+        mock_session.assert_called_with(
+            aws_access_key_id='session2',
+            aws_secret_access_key=None,
+            aws_session_token=None,
+            profile_name=None
+        )
+        self.assertEqual(get_session(), 'session2')
+        self.assertEqual(get_session(aws_access_key_id='session1'), 'session1')
+        self.assertEqual(get_session(), 'session1')
+        self.assertEqual(get_session(aws_access_key_id='session2'), 'session2')
+        self.assertEqual(get_session(), 'session2')

--- a/tests/get_session_tests.py
+++ b/tests/get_session_tests.py
@@ -59,3 +59,10 @@ class TestGetSession(unittest.TestCase):
         self.assertEqual(get_session(), 'session1')
         self.assertEqual(get_session(aws_access_key_id='session2'), 'session2')
         self.assertEqual(get_session(), 'session2')
+
+    @patch('boto3.Session')
+    def test_get_session_no_params(self, mock_session):
+        mock_session.return_value = 'defaultsession'
+        self.assertEqual(get_session(), 'defaultsession')
+        self.assertEqual(get_session(), 'defaultsession')
+        mock_session.assert_called_once_with()

--- a/tests/get_session_tests.py
+++ b/tests/get_session_tests.py
@@ -1,11 +1,10 @@
 import unittest
 from unittest.mock import patch, MagicMock
-from credstash import get_session
+from credstash import get_session, reset_sessions
 
 class TestGetSession(unittest.TestCase):
     def setUp(self):
-        get_session._cached_sessions = {}
-        get_session._last_session = None
+        reset_sessions()
 
     @patch('boto3.Session')
     def test_get_session_initial_session(self, mock_session):


### PR DESCRIPTION
Resolves #255 

Currently, `get_session` caches sessions in a single variable, and the cached session takes priority over explicitly-passed-in parameters. This means that there can only be a single `Session` each time `credstash` is imported, which is set the first time `get_session` is called. All subsequent calls to `get_session` return that session, regardless of input.

This PR adds aliased caching by `aws_access_key_id` to `get_session`. On the first call with any `aws_access_key_id`, a `Session` is created and stored in a dictionary. All subsequent calls with that AKID will re-use the cached `Session`. The existing caching behavior, where a call to `get_session` returns the last-used `Session` is maintained using a `last_session` variable. 

Both the cache and `last_session` can be reset by calling `reset_sessions`. 