### PR TITLE
Add --kms-region argument

### DIFF
--- a/integration_tests/test_kms_region.bats
+++ b/integration_tests/test_kms_region.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+
+# test basic CRUD with separate KMS and DDB regions
+# these tests require a duplicated DDB table in us-east-2
+@test "put secret into credstash" {
+    credstash --region us-east-2 --kms-region us-east-1 put __batstestcred1 secretvalue
+}
+
+@test "read secret from credstash" {
+    SECRET=$(credstash --region us-east-2 --kms-region us-east-1 get __batstestcred1)
+    [ "$SECRET" = secretvalue ]
+}
+
+@test "add a new version to a secret in credstash" {
+    credstash --region us-east-2 --kms-region us-east-1 put __batstestcred1 secretvalue2 -a
+}
+
+@test "read latest version of a secret from credstash" {
+    SECRET=$(credstash --region us-east-2 --kms-region us-east-1 get __batstestcred1)
+    [ "$SECRET" = secretvalue2 ]
+}
+
+@test "read previous version of a secret from credstash" {
+    SECRET=$(credstash --region us-east-2 --kms-region us-east-1 get __batstestcred1 -v 1)
+    [ "$SECRET" = secretvalue ]
+}
+
+@test "delete a secret from credstash" {
+    credstash --region us-east-2 --kms-region us-east-1 delete __batstestcred1
+}


### PR DESCRIPTION
Resolves #257.

## KMS Region
This PR adds a new top-level command-line argument, `--kms-region`. 

### Basic Usage
```
credstash --kms-region us-east-1 --region us-east-2 put secret1 secretvalue
credstash --kms-region us-east-1 --region us-east-2 putall '{"secret": "secretvalue"}'
credstash --kms-region us-east-1 --region us-east-2 get secret1
credstash --kms-region us-east-1 --region us-east-2 getall
```
This argument allows users to set the region from which the `credstash` KMS Key should be read separately from the region in which the `credstash` DynamoDB Table is stored. This allows `credstash` to be used with [DynamoDB Global Tables](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables_HowItWorks.html) with minimal AWS configuration.

Note that the KMS region can be specified for `keys`, `list` and `delete`, but is not used since KMS is not needed for those commands.

### Saving the KMS Region
The KMS region can be saved by running `credstash setup --save-kms-region REGION`. This value is saved in `~/.credstash`. 

### KMS Region Resolution Order
1. `--kms-region` command-line argument
2. Saved KMS region in `~/.credstash` 
If the KMS region is not explicitly specified, it takes the value of `region`, following the normal order of precedence:
3. `--region` command-line argument
4. `AWS_DEFAULT_REGION` environment variable
5. `~/.aws/config`
6. `us-east-1` if no other region is specified

### Library Usage
This PR adds a new keyword argument, `kms_region`, to `getSecret`, `getAllSecrets`, `putSecret`, and `putSecretAutoVersion`.