### PR TITLE
Update get_session() to allow using only profile_name and no access/secret keys

### DIFF
--- a/credstash.py
+++ b/credstash.py
@@ -668,7 +668,7 @@ def get_session(aws_access_key_id=None, aws_secret_access_key=None,
         return get_session._cached_sessions[aws_access_key_id]
     else:
         if get_session._last_session is None:
-            get_session._last_session = boto3.Session()
+            get_session._last_session = boto3.Session(profile_name=profile_name)
         return get_session._last_session
 get_session._cached_sessions = {}
 get_session._last_session = None

--- a/tests/get_session_test.py
+++ b/tests/get_session_test.py
@@ -66,3 +66,13 @@ class TestGetSession(unittest.TestCase):
         self.assertEqual(get_session(), 'defaultsession')
         self.assertEqual(get_session(), 'defaultsession')
         mock_session.assert_called_once_with()
+        
+    @patch('boto3.Session')
+    def test_get_session_specify_profile(self, mock_session):
+        mock_session.return_value = 'session1'
+        get_session(
+            profile_name='profile1'
+        )
+        mock_session.assert_called_once_with(
+            profile_name='profile1'
+        )


### PR DESCRIPTION
We use credstash on our Jenkins workers. The workers use Role based authentication, we have only a ~/.aws/config file, no credentials. When we upgraded to v1.16.2 we started seeing errors:

An error occurred (AccessDeniedException) when calling the Query operation: User: arn:aws:sts::111111111:assumed-role/RoleNameOfDefaultProfile/botocore-session-333333333 is not authorized to perform: dynamodb:Query on resource: arn:aws:dynamodb:us-east-1:111111111:table/secret-credential-store

credstash was not using the profile we passed in with the -p parameter.  After debugging, I discovered it was because boto3.Session() was being called with no parameters and therefore defaulted to the "default" profile. 