### PR TITLE
Resolves #271 #273: Remove explicit logger

### DIFF
--- a/credstash.py
+++ b/credstash.py
@@ -80,7 +80,8 @@ def setup_logging(level, log_file):
     logger.setLevel(level)
 
 # setup logging with default values when imported as a lib
-setup_logging(logging.WARNING, 'credstash.log')
+# don't set explicit logging 
+# setup_logging(logging.WARNING, 'credstash.log')
 
 class KeyService(object):
 


### PR DESCRIPTION
Removing explicit log file creation when imported as library. This is causing issue when process don't have permission to create log file. 
#271 #273 