### PR TITLE
use IOError instead of FileNotFoundError

### DIFF
--- a/credstash.py
+++ b/credstash.py
@@ -638,7 +638,7 @@ def loadConfig():
     try:
         with open(config) as f:
             options = json.load(f)
-    except FileNotFoundError:
+    except IOError:
         options = {}
 
     return options


### PR DESCRIPTION
`FileNotFoundError` does not exist in Python 2, so fall back to `IOError`.