### PR TITLE
doc: add link to k8s credstash operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ A number of great projects exist to provide credstash compatability with other l
 - https://github.com/Narochno/Narochno.Credstash (C#)
 - https://github.com/republicwireless-open/erlcredstash (Erlang)
 - https://github.com/psibi/rucredstash (Rust)
+- https://github.com/ouzi-dev/credstash-operator (Kubernetes)
 
 ## How does it work?
 After you complete the steps in the `Setup` section, you will have an encryption key in KMS (in this README, we will refer to that key as the `master key`), and a credential storage table in DDB.


### PR DESCRIPTION
Hi there - We have developed a Credstash Operator for Kubernetes and have been using it in production for several months now. We think it might be worth adding a link to it for others that might find it useful.

https://github.com/ouzi-dev/credstash-operator