### PR TITLE
setup_requires -> tests_requires, for pytest

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from setuptools import setup
 
 name = 'credstash'
 version = '1.17.1'
+tests_requires=['pytest>=5.4.1']
 
 setup(
     name=name,
@@ -24,14 +25,13 @@ setup(
         'boto3>=1.1.1',
     ],
     extras_require={
-        'YAML': ['PyYAML>=3.10']
+        'YAML': ['PyYAML>=3.10'],
+        'test': tests_requires,
     },
     entry_points={
         'console_scripts': [
             'credstash = credstash:main'
         ]
     },
-    setup_requires=[
-        'pytest>=5.4.1'
-    ],
+    tests_requires=tests_requires,
 )


### PR DESCRIPTION
pytest>=5 isn't compatible with python2 https://github.com/pytest-dev/pytest/blob/eaf7ce9a992cea7506553b7d77fdf9622900ae36/setup.cfg#L43

This makes the python2 version fail, even though it may be compatible, as noted: https://github.com/NixOS/nixpkgs/pull/92561#pullrequestreview-459470792

For your CI, it looks like this is irrelevant because your tox.ini will install it anyway, and the `python setup.py test` command is deprecated anyway.