### PR TITLE
Add support for endpoint_url for local dynamodb table

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ See https://blogs.aws.amazon.com/security/post/Tx3D6U6WSFGOK2H/A-New-and-Standar
 ## Usage
 ```
 usage: credstash [-h] [-r REGION] [--kms-region KMS_REGION] [-t TABLE]
-                 [--log-level LOG_LEVEL] [--log-file LOG_FILE]
+                 [--log-level LOG_LEVEL] [--log-file LOG_FILE] [--endpoint-url DYNAMODB_ENDPOINT_URL]
                  [-p PROFILE | -n ARN]
                  {delete,get,getall,keys,list,put,putall,setup} ...
 
@@ -174,6 +174,9 @@ optional arguments:
                         specified, credstash will use the value of the
                         CREDSTASH_DEFAULT_TABLE env variable, or if that is
                         not set, the value `credential-store` will be used
+  --endpoint-url        
+                        Endpoint URL for the local dynamodb setup using
+                        localstack.
   --log-level LOG_LEVEL
                         Set the log level, default WARNING
   --log-file LOG_FILE   Set the log output file, default credstash.log. Errors

--- a/credstash.py
+++ b/credstash.py
@@ -911,7 +911,7 @@ def get_parser():
                                   "CREDSTASH_DEFAULT_TABLE env variable, "
                                   "or if that is not set, the value "
                                   "`credential-store` will be used")
-    parsers['super'].add_argument("--endpoint_url", default=os.environ.get("DYNAMODB_ENDPOINT_URL", None),
+    parsers['super'].add_argument("--endpoint-url", default=os.environ.get("DYNAMODB_ENDPOINT_URL", None),
                                   help="DynamoDB endpoint to use for credential storage. "
                                   "If not specified, credstash "
                                   "will use the value of the "
@@ -1112,7 +1112,7 @@ def main():
     # test for region
     try:
         region = args.region
-        endpoint_url = args.endpoint_url
+        endpoint_url = args.endpoint-url
         session = get_session(**session_params)
         session.resource('dynamodb', region_name=region, endpoint_url=endpoint_url)
     except botocore.exceptions.NoRegionError:


### PR DESCRIPTION
We will like to use credstash with the local dynamodb table created using https://github.com/localstack/localstack. 

This PR adds support for adding `endpoint_url` while making the session to connect to the local dynamodb table rather than the remote AWS service. 

It accepts the endpoint_url as an argument or via an environment variable `DYNAMODB_ENDPOINT_URL`, defaulting to None. 

Have tested all the functions both with and without the endpoint_url. This will be a non-breaking change. 