### PR TITLE
deleteSecrets add option to silence printing

### DIFF
--- a/credstash.py
+++ b/credstash.py
@@ -591,7 +591,7 @@ def getSecret(name, version="", region=None, table="credential-store", context=N
 
 
 @clean_fail
-def deleteSecrets(name, region=None, table="credential-store",
+def deleteSecrets(name, region=None, table="credential-store", show_stdout=True,
                   **kwargs):
     session = get_session(**kwargs)
     dynamodb = session.resource('dynamodb', region_name=region)
@@ -611,8 +611,9 @@ def deleteSecrets(name, region=None, table="credential-store",
         response = secrets.query(**params)
 
         for secret in response["Items"]:
-            print("Deleting %s -- version %s" %
-                  (secret["name"], secret["version"]))
+            if show_stdout:
+                print("Deleting %s -- version %s" %
+                      (secret["name"], secret["version"]))
             secrets.delete_item(Key=secret)
 
 


### PR DESCRIPTION
I'm writing a small command line utility to replace all the credstash keys from an edited file.  I was wrapping adding keys and deleting keys in the console library "rich" and its progress bars.  I have issues getting the credstash.deleteSecrets to work correctly with rich's progress bar and even putting the call inside a context manager to silence the printing is problematic.  The fix is non-breaking and fixes the problem with using credstash in external scripts. 

Adding keys (credstash.putSecret) plays nicely with an external library like rich and its associated progress bars, deleting keys (credstash.deleteSecrets) did not because of the print statement in the function.  Added parameter "show_output" with a default of true and then wrapped the print in an if clause.